### PR TITLE
feat: Phase 1 認証基盤を実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1322,7 +1321,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.98.0.tgz",
       "integrity": "sha512-Ohc97CtInLwZyiSASz7tT9/Abm/vqnIbO9REp+PivVUII8UZsuI3bngRQnYgJdFoOIwvaEII1fX1qy8x0CyNiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.98.0",
         "@supabase/functions-js": "2.98.0",
@@ -1667,7 +1665,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1736,7 +1733,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2262,7 +2258,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2606,7 +2601,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3208,7 +3202,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3394,7 +3387,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5610,7 +5602,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5620,7 +5611,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6319,7 +6309,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6491,7 +6480,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6787,7 +6775,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/(auth)/auth/callback/route.ts
+++ b/src/app/(auth)/auth/callback/route.ts
@@ -1,19 +1,37 @@
-import { NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
 
-export async function GET(request: Request) {
+export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
   const next = searchParams.get("next") ?? "/";
 
   if (code) {
-    const supabase = await createClient();
+    // リダイレクトレスポンスを先に作成し、cookieをそこにセットする
+    const response = NextResponse.redirect(`${origin}${next}`);
+
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return request.cookies.getAll();
+          },
+          setAll(cookiesToSet) {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              response.cookies.set(name, value, options)
+            );
+          },
+        },
+      }
+    );
+
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
-      return NextResponse.redirect(`${origin}${next}`);
+      return response;
     }
   }
 
-  // 失敗時はログインページへ
   return NextResponse.redirect(`${origin}/login?error=auth_failed`);
 }

--- a/src/app/(auth)/auth/callback/route.ts
+++ b/src/app/(auth)/auth/callback/route.ts
@@ -10,10 +10,24 @@ export async function GET(request: NextRequest) {
     // リダイレクトレスポンスを先に作成し、cookieをそこにセットする
     const response = NextResponse.redirect(`${origin}${next}`);
 
+    const publicUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+    const internalUrl = process.env.SUPABASE_INTERNAL_URL;
+
     const supabase = createServerClient(
-      process.env.SUPABASE_INTERNAL_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      publicUrl,
       process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
       {
+        global: internalUrl
+          ? {
+              fetch: (input, init) => {
+                const url =
+                  typeof input === "string"
+                    ? input.replace(publicUrl, internalUrl)
+                    : input;
+                return fetch(url, init);
+              },
+            }
+          : undefined,
         cookies: {
           getAll() {
             return request.cookies.getAll();

--- a/src/app/(auth)/auth/callback/route.ts
+++ b/src/app/(auth)/auth/callback/route.ts
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
     const response = NextResponse.redirect(`${origin}${next}`);
 
     const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_INTERNAL_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL!,
       process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
       {
         cookies: {

--- a/src/app/(auth)/auth/callback/route.ts
+++ b/src/app/(auth)/auth/callback/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") ?? "/";
+
+  if (code) {
+    const supabase = await createClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`);
+    }
+  }
+
+  // 失敗時はログインページへ
+  return NextResponse.redirect(`${origin}/login?error=auth_failed`);
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,39 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import LoginButton from "@/components/shared/login-button";
+
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>;
+}) {
+  const { error } = await searchParams;
+
+  // すでにログイン済みなら / にリダイレクト
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (user) redirect("/");
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <div className="w-full max-w-sm space-y-6 px-4">
+        <div className="text-center space-y-2">
+          <h1 className="text-2xl font-bold">情報Ⅰ 授業プラットフォーム</h1>
+          <p className="text-sm text-muted-foreground">
+            学校のGoogleアカウントでログインしてください
+          </p>
+        </div>
+
+        {error === "auth_failed" && (
+          <p className="text-sm text-center text-destructive">
+            ログインに失敗しました。もう一度お試しください。
+          </p>
+        )}
+
+        <LoginButton />
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import Link from "next/link";
+import NavBar from "@/components/shared/nav-bar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,30 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen bg-background`}
       >
-        <header className="border-b bg-card sticky top-0 z-10">
-          <div className="max-w-7xl mx-auto px-4 h-14 flex items-center justify-between">
-            <Link
-              href="/"
-              className="font-bold text-lg text-foreground hover:opacity-80 transition-opacity"
-            >
-              情報Ⅰ 授業プラットフォーム
-            </Link>
-            <nav className="flex items-center gap-4 text-sm">
-              <Link
-                href="/"
-                className="text-muted-foreground hover:text-foreground transition-colors"
-              >
-                📺 レッスン一覧
-              </Link>
-              <Link
-                href="/teacher/lessons/new"
-                className="px-3 py-1.5 rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity"
-              >
-                + レッスンを登録
-              </Link>
-            </nav>
-          </div>
-        </header>
+        <NavBar />
         <main>{children}</main>
       </body>
     </html>

--- a/src/components/shared/login-button.tsx
+++ b/src/components/shared/login-button.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { createClient } from "@/lib/supabase/client";
+
+export default function LoginButton() {
+  const handleLogin = async () => {
+    const supabase = createClient();
+    await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+  };
+
+  return (
+    <button
+      onClick={handleLogin}
+      className="w-full flex items-center justify-center gap-3 px-4 py-3 rounded-md border bg-card hover:bg-muted transition-colors text-sm font-medium"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 48 48"
+        className="w-5 h-5"
+      >
+        <path
+          fill="#EA4335"
+          d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+        />
+        <path
+          fill="#4285F4"
+          d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+        />
+        <path
+          fill="#FBBC05"
+          d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+        />
+        <path
+          fill="#34A853"
+          d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+        />
+      </svg>
+      Google でログイン
+    </button>
+  );
+}

--- a/src/components/shared/logout-button.tsx
+++ b/src/components/shared/logout-button.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { createClient } from "@/lib/supabase/client";
+import { useRouter } from "next/navigation";
+
+export default function LogoutButton() {
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    router.push("/login");
+  };
+
+  return (
+    <button
+      onClick={handleLogout}
+      className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+    >
+      ログアウト
+    </button>
+  );
+}

--- a/src/components/shared/nav-bar.tsx
+++ b/src/components/shared/nav-bar.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import LogoutButton from "@/components/shared/logout-button";
+
+export default async function NavBar() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  let displayName = "";
+  if (user) {
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("display_name")
+      .eq("id", user.id)
+      .single();
+    displayName = profile?.display_name ?? user.email ?? "";
+  }
+
+  return (
+    <header className="border-b bg-card sticky top-0 z-10">
+      <div className="max-w-7xl mx-auto px-4 h-14 flex items-center justify-between">
+        <Link
+          href="/"
+          className="font-bold text-lg text-foreground hover:opacity-80 transition-opacity"
+        >
+          情報Ⅰ 授業プラットフォーム
+        </Link>
+        <nav className="flex items-center gap-4 text-sm">
+          <Link
+            href="/"
+            className="text-muted-foreground hover:text-foreground transition-colors"
+          >
+            📺 レッスン一覧
+          </Link>
+          <Link
+            href="/teacher/lessons/new"
+            className="px-3 py-1.5 rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity"
+          >
+            + レッスンを登録
+          </Link>
+          {user && (
+            <>
+              <span className="text-muted-foreground text-xs border-l pl-4">
+                {displayName}
+              </span>
+              <LogoutButton />
+            </>
+          )}
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/src/components/shared/nav-bar.tsx
+++ b/src/components/shared/nav-bar.tsx
@@ -28,20 +28,20 @@ export default async function NavBar() {
           情報Ⅰ 授業プラットフォーム
         </Link>
         <nav className="flex items-center gap-4 text-sm">
-          <Link
-            href="/"
-            className="text-muted-foreground hover:text-foreground transition-colors"
-          >
-            📺 レッスン一覧
-          </Link>
-          <Link
-            href="/teacher/lessons/new"
-            className="px-3 py-1.5 rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity"
-          >
-            + レッスンを登録
-          </Link>
           {user && (
             <>
+              <Link
+                href="/"
+                className="text-muted-foreground hover:text-foreground transition-colors"
+              >
+                📺 レッスン一覧
+              </Link>
+              <Link
+                href="/teacher/lessons/new"
+                className="px-3 py-1.5 rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity"
+              >
+                + レッスンを登録
+              </Link>
               <span className="text-muted-foreground text-xs border-l pl-4">
                 {displayName}
               </span>

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -4,10 +4,24 @@ import { NextResponse, type NextRequest } from "next/server";
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });
 
+  const publicUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const internalUrl = process.env.SUPABASE_INTERNAL_URL;
+
   const supabase = createServerClient(
-    process.env.SUPABASE_INTERNAL_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    publicUrl,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
     {
+      global: internalUrl
+        ? {
+            fetch: (input, init) => {
+              const url =
+                typeof input === "string"
+                  ? input.replace(publicUrl, internalUrl)
+                  : input;
+              return fetch(url, init);
+            },
+          }
+        : undefined,
       cookies: {
         getAll() {
           return request.cookies.getAll();

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,0 +1,48 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+
+export async function updateSession(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({ request });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value)
+          );
+          supabaseResponse = NextResponse.next({ request });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options)
+          );
+        },
+      },
+    }
+  );
+
+  // セッションを更新（必ずgetUser()を呼ぶ）
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // 未認証ユーザーを /login にリダイレクト（認証不要パスを除く）
+  const pathname = request.nextUrl.pathname;
+  const isPublicPath =
+    pathname.startsWith("/login") ||
+    pathname.startsWith("/auth/callback") ||
+    pathname.startsWith("/_next") ||
+    pathname.startsWith("/favicon");
+
+  if (!user && !isPublicPath) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/login";
+    return NextResponse.redirect(url);
+  }
+
+  return supabaseResponse;
+}

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -5,7 +5,7 @@ export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });
 
   const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_INTERNAL_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
     {
       cookies: {

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -5,7 +5,7 @@ export async function createClient() {
   const cookieStore = await cookies();
 
   return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_INTERNAL_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
     {
       cookies: {

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -3,11 +3,24 @@ import { cookies } from "next/headers";
 
 export async function createClient() {
   const cookieStore = await cookies();
+  const publicUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const internalUrl = process.env.SUPABASE_INTERNAL_URL;
 
   return createServerClient(
-    process.env.SUPABASE_INTERNAL_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    publicUrl,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
     {
+      global: internalUrl
+        ? {
+            fetch: (input, init) => {
+              const url =
+                typeof input === "string"
+                  ? input.replace(publicUrl, internalUrl)
+                  : input;
+              return fetch(url, init);
+            },
+          }
+        : undefined,
       cookies: {
         getAll() {
           return cookieStore.getAll();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,18 @@
+import { type NextRequest } from "next/server";
+import { updateSession } from "@/lib/supabase/middleware";
+
+export async function middleware(request: NextRequest) {
+  return await updateSession(request);
+}
+
+export const config = {
+  matcher: [
+    /*
+     * 以下を除くすべてのパスにマッチ:
+     * - _next/static（静的ファイル）
+     * - _next/image（画像最適化）
+     * - favicon.ico
+     */
+    "/((?!_next/static|_next/image|favicon.ico).*)",
+  ],
+};

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -147,9 +147,9 @@ max_indexes = 5
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "http://127.0.0.1:3000"
+site_url = "http://localhost:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+additional_redirect_urls = ["http://localhost:3000", "https://localhost:3000"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
@@ -298,6 +298,12 @@ max_frequency = "5s"
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
 # `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
 # `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.google]
+enabled = true
+client_id = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID)"
+secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET)"
+skip_nonce_check = true
+
 [auth.external.apple]
 enabled = false
 client_id = ""


### PR DESCRIPTION
## 概要
Supabase Auth（Google OAuth）を使った認証基盤を実装。未ログイン時は `/login` へリダイレクトされ、ログイン後のみコンテンツにアクセスできる。

## 変更内容
- `src/middleware.ts`: 未認証ユーザーを `/login` にリダイレクト
- `src/lib/supabase/middleware.ts`: セッション更新ロジック（public path除外）
- `src/lib/supabase/server.ts`: サーバーサイドSupabaseクライアント
- `src/app/(auth)/login/page.tsx`: Googleログインページ
- `src/app/(auth)/auth/callback/route.ts`: OAuthコールバック処理（PKCE対応）
- `src/components/shared/login-button.tsx`: Googleログインボタン（Client Component）
- `src/components/shared/nav-bar.tsx`: ログインユーザー名・ログアウトボタン表示、ナビリンクをログイン後のみ表示
- `src/components/shared/logout-button.tsx`: ログアウトボタン（Client Component）
- Docker環境でのPKCEクッキー名不一致バグを修正（`global.fetch`オーバーライドで内部URLにルーティング）

## 確認事項
- [x] セルフレビュー済み
- [x] 未ログイン時に `/` へアクセスすると `/login` にリダイレクトされることを確認
- [x] Google OAuthでログイン・ログアウトが正常に動作することを確認
- [x] ログイン後にナビバーにユーザー名とログアウトボタンが表示されることを確認