### PR TITLE
fix: middleware.ts を proxy.ts にリネーム（Next.js 16 非推奨対応）

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,7 @@
 import { type NextRequest } from "next/server";
 import { updateSession } from "@/lib/supabase/middleware";
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   return await updateSession(request);
 }
 


### PR DESCRIPTION
## 概要
Next.js 16 で `middleware` ファイル規約が非推奨になり `proxy` への移行が必要なため対応。

## 変更内容
- `src/middleware.ts` → `src/proxy.ts` にリネーム
- エクスポート関数名 `middleware()` → `proxy()` に変更（コードモッド自動適用）
- 動作ロジックは変更なし

## 確認事項
- [x] セルフレビュー済み
- [x] lint / typecheck 通過確認