### PR TITLE
feat: Phase 5 共有投稿機能

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -132,13 +132,16 @@
 
 ### タスク
 
-- [ ] `src/lib/db/posts.ts` を実装（投稿クエリを集約）
-- [ ] `api/posts/` Route Handler を実装（Client Component から `lib/db/posts.ts` を呼ぶ）
+- [x] `src/lib/db/posts.ts` を実装（投稿クエリを集約）
+- [x] `api/posts/` Route Handler を実装（重複チェック付き）
   - `GET /api/posts?lessonId=xxx` — 投稿一覧（全員閲覧可）
-  - `POST /api/posts` — メモから投稿（スナップショット保存）
-- [ ] `PostList` を実データ対応（Server Component から `lib/db/posts.ts` を直接呼ぶ）
-- [ ] 自分の投稿 / 他者の投稿を明示的に区別して表示
-- [ ] 投稿は匿名表示（`display_name` を出さない）
+  - `POST /api/posts` — メモから投稿（重複時 409）
+  - `DELETE /api/posts/[postId]` — 自分の投稿を削除
+- [x] `PostList` を Client Component に書き換え、Supabase Realtime でリアルタイム更新
+- [x] 自分の投稿 / 他者の投稿を明示的に区別して表示（自分の投稿はハイライト・削除ボタン）
+- [x] 投稿は匿名表示（`display_name` を出さない）
+- [x] 投稿フィードバックを toast に統一（成功・重複・失敗）
+- [x] memos/posts ともにクライアントフェッチに統一し page.tsx を簡素化
 
 ### マージ判断
 
@@ -188,9 +191,9 @@ teacher ロール以外が登録・編集できないことを確認してから
 [✅] Phase 2: ルートグループ再構成
 [✅] Phase 3: レッスン一覧・視聴（実データ）
 [✅] Phase 4: メモ機能
-[ ] Phase 5: 共有投稿機能
+[✅] Phase 5: 共有投稿機能
 [ ] Phase 6: 教師機能
 [ ] Phase 7: 小テスト
 ```
 
-次の着手は **Phase 5: 共有投稿機能**。
+次の着手は **Phase 6: 教師機能**。

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,12 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.577.0",
         "next": "16.1.6",
+        "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-youtube": "^10.1.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
       },
@@ -7313,6 +7315,16 @@
         }
       }
     },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -8515,6 +8527,16 @@
       "resolved": "https://registry.npmjs.org/sister/-/sister-3.0.2.tgz",
       "integrity": "sha512-p19rtTs+NksBRKW9qn0UhZ8/TUI9BPw9lmtHny+Y3TinWlOa9jWh9xB0AtPSdmOy49NJJJSSe0Ey4C7h0TrcYA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",
     "next": "16.1.6",
+    "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-youtube": "^10.1.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/src/app/(student)/lessons/[lessonId]/page.tsx
+++ b/src/app/(student)/lessons/[lessonId]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { getLessonWithQuestions } from "@/lib/db/contents";
-import { getMemosByLessonId } from "@/lib/db/memos";
+import { createClient } from "@/lib/supabase/server";
 import LessonContent from "@/components/lesson/lesson-content";
 
 type Props = {
@@ -11,11 +11,14 @@ type Props = {
 export default async function LessonPage({ params }: Props) {
   const { lessonId } = await params;
 
-  const [lesson, memos] = await Promise.all([
+  const supabase = await createClient();
+  const [lesson, { data: { user } }] = await Promise.all([
     getLessonWithQuestions(lessonId),
-    getMemosByLessonId(lessonId),
+    supabase.auth.getUser(),
   ]);
+
   if (!lesson) return notFound();
+  if (!user) return notFound();
 
   const { unit, questions } = lesson;
   const subject = unit.subject;
@@ -41,9 +44,7 @@ export default async function LessonPage({ params }: Props) {
         lessonId={lessonId}
         youtubeUrl={lesson.youtube_url}
         questions={questions}
-        posts={[]}
-        memos={memos}
-        postedMemoIds={[]}
+        currentUserId={user.id}
       />
     </div>
   );

--- a/src/app/api/posts/[postId]/route.ts
+++ b/src/app/api/posts/[postId]/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { deletePost } from "@/lib/db/posts";
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ postId: string }> }
+) {
+  const { postId } = await params;
+
+  const success = await deletePost(postId);
+  if (!success) {
+    return NextResponse.json({ data: null, error: "Failed to delete post" }, { status: 500 });
+  }
+
+  return NextResponse.json({ data: { id: postId }, error: null });
+}

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getPostsByLessonId, createPost } from "@/lib/db/posts";
+import type { TiptapContent } from "@/lib/db/memos";
+
+export async function GET(request: NextRequest) {
+  const lessonId = request.nextUrl.searchParams.get("lessonId");
+  if (!lessonId) {
+    return NextResponse.json({ data: null, error: "lessonId is required" }, { status: 400 });
+  }
+
+  const data = await getPostsByLessonId(lessonId);
+  return NextResponse.json({ data, error: null });
+}
+
+export async function POST(request: NextRequest) {
+  const body = (await request.json()) as {
+    memoId: string;
+    lessonId: string;
+    content: TiptapContent;
+  };
+
+  if (!body.memoId || !body.lessonId || !body.content) {
+    return NextResponse.json(
+      { data: null, error: "memoId, lessonId and content are required" },
+      { status: 400 }
+    );
+  }
+
+  const data = await createPost({
+    memoId: body.memoId,
+    lessonId: body.lessonId,
+    content: body.content,
+  });
+
+  if (!data) {
+    return NextResponse.json({ data: null, error: "Failed to create post" }, { status: 500 });
+  }
+
+  return NextResponse.json({ data, error: null }, { status: 201 });
+}

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { getPostsByLessonId, createPost } from "@/lib/db/posts";
+import { getPostsByLessonId, createPost, existsPostByMemoId } from "@/lib/db/posts";
 import type { TiptapContent } from "@/lib/db/memos";
 
 export async function GET(request: NextRequest) {
@@ -24,6 +24,11 @@ export async function POST(request: NextRequest) {
       { data: null, error: "memoId, lessonId and content are required" },
       { status: 400 }
     );
+  }
+
+  const alreadyExists = await existsPostByMemoId(body.memoId);
+  if (alreadyExists) {
+    return NextResponse.json({ data: null, error: "already_posted" }, { status: 409 });
   }
 
   const data = await createPost({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import NavBar from "@/components/shared/nav-bar";
+import { Toaster } from "@/components/ui/sonner";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,6 +31,7 @@ export default function RootLayout({
       >
         <NavBar />
         <main>{children}</main>
+        <Toaster />
       </body>
     </html>
   );

--- a/src/components/lesson/lesson-content.tsx
+++ b/src/components/lesson/lesson-content.tsx
@@ -3,8 +3,6 @@
 import { useState, useRef } from "react";
 import type { YouTubePlayer } from "react-youtube";
 import type { Question } from "@/lib/db/contents";
-import type { Memo } from "@/lib/db/memos";
-import type { Post } from "@/lib/db/posts";
 import LessonTabs from "@/components/lesson/lesson-tabs";
 import MemoSection from "@/components/lesson/memo-section";
 import PostList from "@/components/lesson/post-list";
@@ -13,18 +11,14 @@ type Props = {
   lessonId: string;
   youtubeUrl: string;
   questions: Question[];
-  posts: Post[];
-  memos: Memo[];
-  postedMemoIds: string[];
+  currentUserId: string;
 };
 
 export default function LessonContent({
   lessonId,
   youtubeUrl,
   questions,
-  posts,
-  memos,
-  postedMemoIds,
+  currentUserId,
 }: Props) {
   const [memoVisible, setMemoVisible] = useState(true);
   const playerRef = useRef<YouTubePlayer | null>(null);
@@ -56,10 +50,12 @@ export default function LessonContent({
           <LessonTabs
             youtubeUrl={youtubeUrl}
             questions={questions}
-            onPlayerReady={(player) => { playerRef.current = player; }}
+            onPlayerReady={(player) => {
+              playerRef.current = player;
+            }}
           />
           <div className="border-t pt-6">
-            <PostList posts={posts} />
+            <PostList lessonId={lessonId} currentUserId={currentUserId} />
           </div>
         </div>
 
@@ -67,11 +63,9 @@ export default function LessonContent({
           <div className="col-span-1">
             <MemoSection
               lessonId={lessonId}
-              initialMemos={memos}
-              initialPostedMemoIds={postedMemoIds}
-              onClose={() => setMemoVisible(false)}
               getCurrentTime={getCurrentTime}
               seekTo={seekTo}
+              onClose={() => setMemoVisible(false)}
             />
           </div>
         )}

--- a/src/components/lesson/memo-section.tsx
+++ b/src/components/lesson/memo-section.tsx
@@ -5,11 +5,10 @@ import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import type { Memo } from "@/lib/db/memos";
+import type { Post } from "@/lib/db/posts";
 
 type Props = {
   lessonId: string;
-  initialMemos: Memo[];
-  initialPostedMemoIds: string[];
   getCurrentTime: () => number | null;
   seekTo: (seconds: number) => void;
   onClose?: () => void;
@@ -30,19 +29,10 @@ function formatDate(dateString: string): string {
   });
 }
 
-export default function MemoSection({
-  lessonId,
-  initialMemos,
-  initialPostedMemoIds,
-  getCurrentTime,
-  seekTo,
-  onClose,
-}: Props) {
+export default function MemoSection({ lessonId, getCurrentTime, seekTo, onClose }: Props) {
   const [timestamp, setTimestamp] = useState<number | null>(null);
-  const [memos, setMemos] = useState<Memo[]>(initialMemos);
-  const [postedIds, setPostedIds] = useState<Set<string>>(
-    new Set(initialPostedMemoIds)
-  );
+  const [memos, setMemos] = useState<Memo[]>([]);
+  const [postedIds, setPostedIds] = useState<Set<string>>(new Set());
   const [saveState, setSaveState] = useState<"idle" | "saving" | "saved">("idle");
   const [editorEmpty, setEditorEmpty] = useState(true);
 
@@ -57,19 +47,27 @@ export default function MemoSection({
     ],
     editorProps: {
       attributes: {
-        class:
-          "min-h-[120px] p-3 text-sm focus:outline-none",
+        class: "min-h-[120px] p-3 text-sm focus:outline-none",
       },
     },
   });
 
   useEffect(() => {
-    fetch(`/api/memos?lessonId=${lessonId}`)
-      .then((res) => res.json())
-      .then((json: { data: Memo[] | null; error: string | null }) => {
-        if (json.data) setMemos(json.data);
-      })
-      .catch(() => {});
+    const fetchData = async () => {
+      const [memosRes, postsRes] = await Promise.all([
+        fetch(`/api/memos?lessonId=${lessonId}`),
+        fetch(`/api/posts?lessonId=${lessonId}`),
+      ]);
+      const memosJson = (await memosRes.json()) as { data: Memo[] | null };
+      const postsJson = (await postsRes.json()) as { data: Post[] | null };
+
+      if (memosJson.data) setMemos(memosJson.data);
+      if (postsJson.data) {
+        const ids = new Set(postsJson.data.map((p) => p.memo_id));
+        setPostedIds(ids);
+      }
+    };
+    fetchData().catch(() => {});
   }, [lessonId]);
 
   const handleTimestamp = () => {
@@ -105,8 +103,15 @@ export default function MemoSection({
     }
   };
 
-  const handlePost = (memoId: string) => {
-    setPostedIds((prev) => new Set([...prev, memoId]));
+  const handlePost = async (memo: Memo) => {
+    const res = await fetch("/api/posts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ memoId: memo.id, lessonId, content: memo.content }),
+    });
+    if (res.ok) {
+      setPostedIds((prev) => new Set([...prev, memo.id]));
+    }
   };
 
   return (
@@ -163,10 +168,7 @@ export default function MemoSection({
           </p>
           <div className="space-y-2">
             {memos.map((m) => (
-              <div
-                key={m.id}
-                className="p-3 rounded-md border bg-background space-y-1.5"
-              >
+              <div key={m.id} className="p-3 rounded-md border bg-background space-y-1.5">
                 <div className="flex items-start justify-between gap-2">
                   <p className="text-xs text-muted-foreground">
                     {m.timestamp_seconds !== null ? (
@@ -199,7 +201,7 @@ export default function MemoSection({
                   <p className="text-xs text-muted-foreground">投稿済み ✅</p>
                 ) : (
                   <button
-                    onClick={() => handlePost(m.id)}
+                    onClick={() => handlePost(m)}
                     className="text-xs px-2 py-1 rounded-md border hover:bg-muted transition-colors"
                   >
                     クラスに投稿

--- a/src/components/lesson/memo-section.tsx
+++ b/src/components/lesson/memo-section.tsx
@@ -4,8 +4,8 @@ import { useState, useEffect } from "react";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
+import { toast } from "sonner";
 import type { Memo } from "@/lib/db/memos";
-import type { Post } from "@/lib/db/posts";
 
 type Props = {
   lessonId: string;
@@ -32,7 +32,6 @@ function formatDate(dateString: string): string {
 export default function MemoSection({ lessonId, getCurrentTime, seekTo, onClose }: Props) {
   const [timestamp, setTimestamp] = useState<number | null>(null);
   const [memos, setMemos] = useState<Memo[]>([]);
-  const [postedIds, setPostedIds] = useState<Set<string>>(new Set());
   const [saveState, setSaveState] = useState<"idle" | "saving" | "saved">("idle");
   const [editorEmpty, setEditorEmpty] = useState(true);
 
@@ -53,21 +52,12 @@ export default function MemoSection({ lessonId, getCurrentTime, seekTo, onClose 
   });
 
   useEffect(() => {
-    const fetchData = async () => {
-      const [memosRes, postsRes] = await Promise.all([
-        fetch(`/api/memos?lessonId=${lessonId}`),
-        fetch(`/api/posts?lessonId=${lessonId}`),
-      ]);
-      const memosJson = (await memosRes.json()) as { data: Memo[] | null };
-      const postsJson = (await postsRes.json()) as { data: Post[] | null };
-
-      if (memosJson.data) setMemos(memosJson.data);
-      if (postsJson.data) {
-        const ids = new Set(postsJson.data.map((p) => p.memo_id));
-        setPostedIds(ids);
-      }
-    };
-    fetchData().catch(() => {});
+    fetch(`/api/memos?lessonId=${lessonId}`)
+      .then((res) => res.json())
+      .then((json: { data: Memo[] | null }) => {
+        if (json.data) setMemos(json.data);
+      })
+      .catch(() => {});
   }, [lessonId]);
 
   const handleTimestamp = () => {
@@ -109,8 +99,14 @@ export default function MemoSection({ lessonId, getCurrentTime, seekTo, onClose 
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ memoId: memo.id, lessonId, content: memo.content }),
     });
+    if (res.status === 409) {
+      toast.warning("このメモはすでに投稿済みです");
+      return;
+    }
     if (res.ok) {
-      setPostedIds((prev) => new Set([...prev, memo.id]));
+      toast.success("クラスに投稿しました");
+    } else {
+      toast.error("投稿に失敗しました");
     }
   };
 
@@ -197,16 +193,12 @@ export default function MemoSection({ lessonId, getCurrentTime, seekTo, onClose 
                     .map((node) => node.text)
                     .join("")}
                 </p>
-                {postedIds.has(m.id) ? (
-                  <p className="text-xs text-muted-foreground">投稿済み ✅</p>
-                ) : (
-                  <button
-                    onClick={() => handlePost(m)}
-                    className="text-xs px-2 py-1 rounded-md border hover:bg-muted transition-colors"
-                  >
-                    クラスに投稿
-                  </button>
-                )}
+                <button
+                  onClick={() => handlePost(m)}
+                  className="text-xs px-2 py-1 rounded-md border hover:bg-muted transition-colors"
+                >
+                  クラスに投稿
+                </button>
               </div>
             ))}
           </div>

--- a/src/components/lesson/post-list.tsx
+++ b/src/components/lesson/post-list.tsx
@@ -1,8 +1,13 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { createClient } from "@/lib/supabase/client";
 import type { Post } from "@/lib/db/posts";
 import type { TiptapContent } from "@/lib/db/memos";
 
 type Props = {
-  posts: Post[];
+  lessonId: string;
+  currentUserId: string;
 };
 
 function extractText(content: TiptapContent): string {
@@ -22,7 +27,39 @@ function formatDate(dateString: string): string {
   });
 }
 
-export default function PostList({ posts }: Props) {
+export default function PostList({ lessonId, currentUserId }: Props) {
+  const [posts, setPosts] = useState<Post[]>([]);
+
+  useEffect(() => {
+    fetch(`/api/posts?lessonId=${lessonId}`)
+      .then((res) => res.json())
+      .then((json: { data: Post[] | null; error: string | null }) => {
+        if (json.data) setPosts(json.data);
+      })
+      .catch(() => {});
+
+    const supabase = createClient();
+    const channel = supabase
+      .channel(`posts:${lessonId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "posts",
+          filter: `lesson_id=eq.${lessonId}`,
+        },
+        (payload) => {
+          setPosts((prev) => [payload.new as Post, ...prev]);
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [lessonId]);
+
   return (
     <section>
       <h2 className="text-base font-semibold mb-4">
@@ -38,14 +75,21 @@ export default function PostList({ posts }: Props) {
         <p className="text-sm text-muted-foreground">📭 まだ投稿はありません。</p>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {posts.map((post) => (
-            <div key={post.id} className="p-4 rounded-lg border bg-card">
-              <p className="text-sm leading-relaxed">{extractText(post.content)}</p>
-              <p className="text-xs text-muted-foreground mt-3">
-                {formatDate(post.created_at)}
-              </p>
-            </div>
-          ))}
+          {posts.map((post) => {
+            const isMyPost = post.user_id === currentUserId;
+            return (
+              <div
+                key={post.id}
+                className={`p-4 rounded-lg border bg-card ${isMyPost ? "border-primary/40" : ""}`}
+              >
+                {isMyPost && (
+                  <p className="text-xs text-primary font-medium mb-1">自分の投稿</p>
+                )}
+                <p className="text-sm leading-relaxed">{extractText(post.content)}</p>
+                <p className="text-xs text-muted-foreground mt-3">{formatDate(post.created_at)}</p>
+              </div>
+            );
+          })}
         </div>
       )}
     </section>

--- a/src/components/lesson/post-list.tsx
+++ b/src/components/lesson/post-list.tsx
@@ -53,12 +53,31 @@ export default function PostList({ lessonId, currentUserId }: Props) {
           setPosts((prev) => [payload.new as Post, ...prev]);
         }
       )
+      .on(
+        "postgres_changes",
+        {
+          event: "DELETE",
+          schema: "public",
+          table: "posts",
+          filter: `lesson_id=eq.${lessonId}`,
+        },
+        (payload) => {
+          setPosts((prev) => prev.filter((p) => p.id !== payload.old.id));
+        }
+      )
       .subscribe();
 
     return () => {
       supabase.removeChannel(channel);
     };
   }, [lessonId]);
+
+  const handleDelete = async (postId: string) => {
+    const res = await fetch(`/api/posts/${postId}`, { method: "DELETE" });
+    if (res.ok) {
+      setPosts((prev) => prev.filter((p) => p.id !== postId));
+    }
+  };
 
   return (
     <section>
@@ -82,9 +101,20 @@ export default function PostList({ lessonId, currentUserId }: Props) {
                 key={post.id}
                 className={`p-4 rounded-lg border bg-card ${isMyPost ? "border-primary/40" : ""}`}
               >
-                {isMyPost && (
-                  <p className="text-xs text-primary font-medium mb-1">自分の投稿</p>
-                )}
+                <div className="flex items-start justify-between gap-2">
+                  {isMyPost && (
+                    <p className="text-xs text-primary font-medium">自分の投稿</p>
+                  )}
+                  {isMyPost && (
+                    <button
+                      onClick={() => handleDelete(post.id)}
+                      className="text-xs text-muted-foreground hover:text-destructive transition-colors shrink-0"
+                      aria-label="投稿を削除"
+                    >
+                      🗑️
+                    </button>
+                  )}
+                </div>
                 <p className="text-sm leading-relaxed">{extractText(post.content)}</p>
                 <p className="text-xs text-muted-foreground mt-3">{formatDate(post.created_at)}</p>
               </div>

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react"
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/src/lib/db/posts.ts
+++ b/src/lib/db/posts.ts
@@ -50,3 +50,14 @@ export async function createPost(params: {
   if (error || !data) return null;
   return data as Post;
 }
+
+/**
+ * 自分の投稿を削除する
+ */
+export async function deletePost(postId: string): Promise<boolean> {
+  const supabase = await createClient();
+
+  const { error } = await supabase.from("posts").delete().eq("id", postId);
+
+  return !error;
+}

--- a/src/lib/db/posts.ts
+++ b/src/lib/db/posts.ts
@@ -1,6 +1,52 @@
+import { createClient } from "@/lib/supabase/server";
 import type { Database } from "@/lib/supabase/types";
 import type { TiptapContent } from "@/lib/db/memos";
 
 export type Post = Database["public"]["Tables"]["posts"]["Row"] & {
   content: TiptapContent;
 };
+
+/**
+ * 指定レッスンの投稿一覧を取得する（全認証ユーザーが閲覧可）
+ */
+export async function getPostsByLessonId(lessonId: string): Promise<Post[]> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("posts")
+    .select("*")
+    .eq("lesson_id", lessonId)
+    .order("created_at", { ascending: false });
+
+  if (error || !data) return [];
+  return data as Post[];
+}
+
+/**
+ * メモからクラスに投稿する
+ */
+export async function createPost(params: {
+  memoId: string;
+  lessonId: string;
+  content: TiptapContent;
+}): Promise<Post | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const { data, error } = await supabase
+    .from("posts")
+    .insert({
+      memo_id: params.memoId,
+      lesson_id: params.lessonId,
+      content: params.content,
+      user_id: user.id,
+    })
+    .select()
+    .single();
+
+  if (error || !data) return null;
+  return data as Post;
+}

--- a/src/lib/db/posts.ts
+++ b/src/lib/db/posts.ts
@@ -23,6 +23,21 @@ export async function getPostsByLessonId(lessonId: string): Promise<Post[]> {
 }
 
 /**
+ * 指定メモの投稿が既に存在するか確認する
+ */
+export async function existsPostByMemoId(memoId: string): Promise<boolean> {
+  const supabase = await createClient();
+
+  const { data } = await supabase
+    .from("posts")
+    .select("id")
+    .eq("memo_id", memoId)
+    .maybeSingle();
+
+  return data !== null;
+}
+
+/**
  * メモからクラスに投稿する
  */
 export async function createPost(params: {

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -121,6 +121,7 @@ export type Database = {
           id: string
           lesson_id: string
           memo_id: string
+          user_id: string
         }
         Insert: {
           content?: Json
@@ -128,6 +129,7 @@ export type Database = {
           id?: string
           lesson_id: string
           memo_id: string
+          user_id: string
         }
         Update: {
           content?: Json
@@ -135,6 +137,7 @@ export type Database = {
           id?: string
           lesson_id?: string
           memo_id?: string
+          user_id?: string
         }
         Relationships: [
           {

--- a/supabase/migrations/20260308000003_posts_user_id_realtime.sql
+++ b/supabase/migrations/20260308000003_posts_user_id_realtime.sql
@@ -1,0 +1,28 @@
+-- =====================
+-- posts に user_id カラムを追加（投稿者識別のため）
+-- =====================
+
+ALTER TABLE public.posts
+  ADD COLUMN user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE;
+
+-- =====================
+-- RLS ポリシーを更新（user_id も検証）
+-- =====================
+
+DROP POLICY "posts: 本人のメモからのみ作成" ON public.posts;
+
+CREATE POLICY "posts: 本人のメモからのみ作成"
+  ON public.posts FOR INSERT
+  WITH CHECK (
+    user_id = auth.uid()
+    AND EXISTS (
+      SELECT 1 FROM public.memos
+      WHERE id = memo_id AND user_id = auth.uid()
+    )
+  );
+
+-- =====================
+-- Realtime を有効化
+-- =====================
+
+ALTER PUBLICATION supabase_realtime ADD TABLE public.posts;

--- a/supabase/migrations/20260308000004_posts_delete_policy.sql
+++ b/supabase/migrations/20260308000004_posts_delete_policy.sql
@@ -1,0 +1,4 @@
+-- posts: 本人のみ削除可
+CREATE POLICY "posts: 本人のみ削除"
+  ON public.posts FOR DELETE
+  USING (user_id = auth.uid());


### PR DESCRIPTION
## 概要
メモをクラスに匿名共有する投稿機能を実装した。Supabase Realtime によるリアルタイム更新対応。

## 変更内容
- migration: `posts` に `user_id` カラム追加・Realtime 有効化・削除 RLS ポリシー追加
- `lib/db/posts.ts`: `getPostsByLessonId` / `existsPostByMemoId` / `createPost` / `deletePost` を実装
- `api/posts/route.ts`: GET・POST（重複チェック付き）を実装
- `api/posts/[postId]/route.ts`: DELETE を実装
- `post-list.tsx`: Supabase Realtime で INSERT/DELETE をリアルタイム購読、自分の投稿をハイライト・削除ボタン表示
- `memo-section.tsx`: `postedIds` state を廃止し常時「クラスに投稿」ボタン表示、toast でフィードバック
- `lesson-content.tsx` / `page.tsx`: props を `currentUserId` に整理、クライアントフェッチに統一
- sonner を導入し `Toaster` をルートレイアウトに追加

## 確認事項
- [x] セルフレビュー済み
- [x] lint / typecheck 通過
- [x] 投稿・重複投稿・削除・リアルタイム更新の動作確認済み