### PR TITLE
feat: Phase 8 エディタ強化・投稿タイムスタンプ引き継ぎ

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -81,6 +81,7 @@ subjects
 | lesson_id | uuid | FK → lessons（クエリ効率化のため非正規化） |
 | user_id | uuid | FK → profiles（投稿者。自分の投稿判定・削除権限に使用） |
 | content | jsonb | 共有時点のスナップショット |
+| timestamp_seconds | int | nullable、投稿元メモのタイムスタンプ |
 | created_at | timestamptz | |
 
 ### quizzes

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.98.0",
+        "@tiptap/extension-link": "^3.20.1",
         "@tiptap/extension-placeholder": "^3.20.1",
         "@tiptap/react": "^3.20.1",
         "@tiptap/starter-kit": "^3.20.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.98.0",
+    "@tiptap/extension-link": "^3.20.1",
     "@tiptap/extension-placeholder": "^3.20.1",
     "@tiptap/react": "^3.20.1",
     "@tiptap/starter-kit": "^3.20.1",

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -17,6 +17,7 @@ export async function POST(request: NextRequest) {
     memoId: string;
     lessonId: string;
     content: TiptapContent;
+    timestampSeconds: number | null;
   };
 
   if (!body.memoId || !body.lessonId || !body.content) {
@@ -35,6 +36,7 @@ export async function POST(request: NextRequest) {
     memoId: body.memoId,
     lessonId: body.lessonId,
     content: body.content,
+    timestampSeconds: body.timestampSeconds ?? null,
   });
 
   if (!data) {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -92,6 +92,35 @@
   }
 }
 
+/* tiptap エディタ内スタイル */
+.ProseMirror h2 {
+  @apply text-base font-semibold mt-2 mb-1;
+}
+
+.ProseMirror ul {
+  @apply list-disc pl-5 space-y-0.5;
+}
+
+.ProseMirror ol {
+  @apply list-decimal pl-5 space-y-0.5;
+}
+
+.ProseMirror li {
+  @apply text-sm;
+}
+
+.ProseMirror a {
+  @apply text-primary underline underline-offset-2;
+}
+
+.ProseMirror p.is-editor-empty:first-child::before {
+  @apply text-muted-foreground;
+  content: attr(data-placeholder);
+  float: left;
+  pointer-events: none;
+  height: 0;
+}
+
 /* tiptap リッチテキスト表示用スタイル */
 .rich-content h2 {
   @apply text-base font-semibold mt-3 mb-1;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -91,3 +91,40 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* tiptap リッチテキスト表示用スタイル */
+.rich-content h2 {
+  @apply text-base font-semibold mt-3 mb-1;
+}
+
+.rich-content ul {
+  @apply list-disc pl-5 space-y-0.5;
+}
+
+.rich-content ol {
+  @apply list-decimal pl-5 space-y-0.5;
+}
+
+.rich-content li {
+  @apply text-sm;
+}
+
+.rich-content strong {
+  @apply font-semibold;
+}
+
+.rich-content em {
+  @apply italic;
+}
+
+.rich-content a {
+  @apply text-primary underline underline-offset-2 hover:opacity-80;
+}
+
+.rich-content p {
+  @apply text-sm leading-relaxed;
+}
+
+.rich-content p + p {
+  @apply mt-1;
+}

--- a/src/components/lesson/lesson-content.tsx
+++ b/src/components/lesson/lesson-content.tsx
@@ -55,7 +55,7 @@ export default function LessonContent({
             }}
           />
           <div className="border-t pt-6">
-            <PostList lessonId={lessonId} currentUserId={currentUserId} />
+            <PostList lessonId={lessonId} currentUserId={currentUserId} seekTo={seekTo} />
           </div>
         </div>
 

--- a/src/components/lesson/memo-section.tsx
+++ b/src/components/lesson/memo-section.tsx
@@ -191,7 +191,7 @@ export default function MemoSection({ lessonId, getCurrentTime, seekTo, onClose 
                   </button>
                 </div>
                 <div
-                  className="text-sm leading-relaxed prose prose-sm max-w-none"
+                  className="rich-content"
                   dangerouslySetInnerHTML={{
                     __html: generateHTML(m.content, [StarterKit, Link]),
                   }}

--- a/src/components/lesson/memo-section.tsx
+++ b/src/components/lesson/memo-section.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useEditor, EditorContent } from "@tiptap/react";
+import { useEditor, EditorContent, generateHTML } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
+import Link from "@tiptap/extension-link";
 import Placeholder from "@tiptap/extension-placeholder";
 import { toast } from "sonner";
 import type { Memo } from "@/lib/db/memos";
+import MemoToolbar from "@/components/lesson/memo-toolbar";
 
 type Props = {
   lessonId: string;
@@ -42,6 +44,7 @@ export default function MemoSection({ lessonId, getCurrentTime, seekTo, onClose 
     },
     extensions: [
       StarterKit,
+      Link.configure({ openOnClick: false }),
       Placeholder.configure({ placeholder: "動画を見て気づいたことや疑問をメモしよう..." }),
     ],
     editorProps: {
@@ -141,6 +144,7 @@ export default function MemoSection({ lessonId, getCurrentTime, seekTo, onClose 
 
       {/* tiptap エディタ */}
       <div className="rounded-md border bg-background focus-within:ring-2 focus-within:ring-ring">
+        {editor && <MemoToolbar editor={editor} />}
         <EditorContent editor={editor} />
       </div>
 
@@ -186,13 +190,12 @@ export default function MemoSection({ lessonId, getCurrentTime, seekTo, onClose 
                     🗑️
                   </button>
                 </div>
-                <p className="text-sm leading-relaxed whitespace-pre-wrap">
-                  {m.content.content
-                    .flatMap((node) => node.content ?? [])
-                    .filter((node) => node.type === "text")
-                    .map((node) => node.text)
-                    .join("")}
-                </p>
+                <div
+                  className="text-sm leading-relaxed prose prose-sm max-w-none"
+                  dangerouslySetInnerHTML={{
+                    __html: generateHTML(m.content, [StarterKit, Link]),
+                  }}
+                />
                 <button
                   onClick={() => handlePost(m)}
                   className="text-xs px-2 py-1 rounded-md border hover:bg-muted transition-colors"

--- a/src/components/lesson/memo-section.tsx
+++ b/src/components/lesson/memo-section.tsx
@@ -100,7 +100,7 @@ export default function MemoSection({ lessonId, getCurrentTime, seekTo, onClose 
     const res = await fetch("/api/posts", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ memoId: memo.id, lessonId, content: memo.content }),
+      body: JSON.stringify({ memoId: memo.id, lessonId, content: memo.content, timestampSeconds: memo.timestamp_seconds }),
     });
     if (res.status === 409) {
       toast.warning("このメモはすでに投稿済みです");

--- a/src/components/lesson/memo-toolbar.tsx
+++ b/src/components/lesson/memo-toolbar.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import type { Editor } from "@tiptap/react";
+import { useState } from "react";
+
+type Props = {
+  editor: Editor;
+};
+
+type ToolbarButtonProps = {
+  onClick: () => void;
+  isActive?: boolean;
+  title: string;
+  children: React.ReactNode;
+};
+
+function ToolbarButton({ onClick, isActive, title, children }: ToolbarButtonProps) {
+  return (
+    <button
+      type="button"
+      onMouseDown={(e) => {
+        e.preventDefault();
+        onClick();
+      }}
+      title={title}
+      className={`px-2 py-1 rounded text-sm transition-colors ${
+        isActive
+          ? "bg-primary text-primary-foreground"
+          : "text-muted-foreground hover:text-foreground hover:bg-muted"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default function MemoToolbar({ editor }: Props) {
+  const [showLinkInput, setShowLinkInput] = useState(false);
+  const [linkUrl, setLinkUrl] = useState("");
+
+  const handleSetLink = () => {
+    if (!linkUrl) {
+      editor.chain().focus().unsetLink().run();
+    } else {
+      editor.chain().focus().setLink({ href: linkUrl }).run();
+    }
+    setLinkUrl("");
+    setShowLinkInput(false);
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-0.5 px-2 py-1 border-b bg-muted/30">
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleBold().run()}
+        isActive={editor.isActive("bold")}
+        title="太字"
+      >
+        <strong>B</strong>
+      </ToolbarButton>
+
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleItalic().run()}
+        isActive={editor.isActive("italic")}
+        title="斜体"
+      >
+        <em>I</em>
+      </ToolbarButton>
+
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+        isActive={editor.isActive("heading", { level: 2 })}
+        title="見出し"
+      >
+        H2
+      </ToolbarButton>
+
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleBulletList().run()}
+        isActive={editor.isActive("bulletList")}
+        title="箇条書き"
+      >
+        ≡
+      </ToolbarButton>
+
+      <ToolbarButton
+        onClick={() => setShowLinkInput((v) => !v)}
+        isActive={editor.isActive("link") || showLinkInput}
+        title="リンク"
+      >
+        🔗
+      </ToolbarButton>
+
+      {showLinkInput && (
+        <div className="flex items-center gap-1 ml-1">
+          <input
+            type="url"
+            value={linkUrl}
+            onChange={(e) => setLinkUrl(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleSetLink();
+              if (e.key === "Escape") setShowLinkInput(false);
+            }}
+            placeholder="https://..."
+            className="text-xs border rounded px-2 py-0.5 w-44 bg-background focus:outline-none focus:ring-1 focus:ring-ring"
+            autoFocus
+          />
+          <button
+            type="button"
+            onClick={handleSetLink}
+            className="text-xs px-2 py-0.5 rounded bg-primary text-primary-foreground"
+          >
+            設定
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/lesson/post-list.tsx
+++ b/src/components/lesson/post-list.tsx
@@ -3,19 +3,17 @@
 import { useState, useEffect } from "react";
 import { createClient } from "@/lib/supabase/client";
 import type { Post } from "@/lib/db/posts";
-import type { TiptapContent } from "@/lib/db/memos";
 
 type Props = {
   lessonId: string;
   currentUserId: string;
+  seekTo: (seconds: number) => void;
 };
 
-function extractText(content: TiptapContent): string {
-  return content.content
-    .flatMap((node) => node.content ?? [])
-    .filter((node) => node.type === "text")
-    .map((node) => node.text)
-    .join("");
+function formatTimestamp(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
 }
 
 function formatDate(dateString: string): string {
@@ -27,7 +25,7 @@ function formatDate(dateString: string): string {
   });
 }
 
-export default function PostList({ lessonId, currentUserId }: Props) {
+export default function PostList({ lessonId, currentUserId, seekTo }: Props) {
   const [posts, setPosts] = useState<Post[]>([]);
 
   useEffect(() => {
@@ -115,7 +113,21 @@ export default function PostList({ lessonId, currentUserId }: Props) {
                     </button>
                   )}
                 </div>
-                <p className="text-sm leading-relaxed">{extractText(post.content)}</p>
+                {post.timestamp_seconds !== null && (
+                  <button
+                    onClick={() => seekTo(post.timestamp_seconds!)}
+                    className="text-xs text-primary hover:underline mb-1 block"
+                  >
+                    📍 {formatTimestamp(post.timestamp_seconds)}
+                  </button>
+                )}
+                <p className="text-sm leading-relaxed whitespace-pre-wrap">
+                  {post.content.content
+                    .flatMap((node) => node.content ?? [])
+                    .filter((node) => node.type === "text")
+                    .map((node) => node.text)
+                    .join("")}
+                </p>
                 <p className="text-xs text-muted-foreground mt-3">{formatDate(post.created_at)}</p>
               </div>
             );

--- a/src/components/lesson/post-list.tsx
+++ b/src/components/lesson/post-list.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { generateHTML } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import Link from "@tiptap/extension-link";
 import { createClient } from "@/lib/supabase/client";
 import type { Post } from "@/lib/db/posts";
 
@@ -121,13 +124,12 @@ export default function PostList({ lessonId, currentUserId, seekTo }: Props) {
                     📍 {formatTimestamp(post.timestamp_seconds)}
                   </button>
                 )}
-                <p className="text-sm leading-relaxed whitespace-pre-wrap">
-                  {post.content.content
-                    .flatMap((node) => node.content ?? [])
-                    .filter((node) => node.type === "text")
-                    .map((node) => node.text)
-                    .join("")}
-                </p>
+                <div
+                  className="rich-content"
+                  dangerouslySetInnerHTML={{
+                    __html: generateHTML(post.content, [StarterKit, Link]),
+                  }}
+                />
                 <p className="text-xs text-muted-foreground mt-3">{formatDate(post.created_at)}</p>
               </div>
             );

--- a/src/lib/db/posts.ts
+++ b/src/lib/db/posts.ts
@@ -2,8 +2,9 @@ import { createClient } from "@/lib/supabase/server";
 import type { Database } from "@/lib/supabase/types";
 import type { TiptapContent } from "@/lib/db/memos";
 
-export type Post = Database["public"]["Tables"]["posts"]["Row"] & {
+export type Post = Omit<Database["public"]["Tables"]["posts"]["Row"], "content"> & {
   content: TiptapContent;
+  timestamp_seconds: number | null;
 };
 
 /**
@@ -44,6 +45,7 @@ export async function createPost(params: {
   memoId: string;
   lessonId: string;
   content: TiptapContent;
+  timestampSeconds: number | null;
 }): Promise<Post | null> {
   const supabase = await createClient();
   const {
@@ -58,6 +60,7 @@ export async function createPost(params: {
       lesson_id: params.lessonId,
       content: params.content,
       user_id: user.id,
+      timestamp_seconds: params.timestampSeconds,
     })
     .select()
     .single();

--- a/supabase/migrations/20260309000002_posts_timestamp_seconds.sql
+++ b/supabase/migrations/20260309000002_posts_timestamp_seconds.sql
@@ -1,0 +1,3 @@
+-- posts テーブルに timestamp_seconds カラムを追加（メモ投稿時のタイムスタンプを引き継ぐ）
+alter table public.posts
+  add column timestamp_seconds int default null;


### PR DESCRIPTION
## 概要
Tiptap エディタのリッチ化と、メモ・投稿のリッチテキスト表示対応、および投稿時のタイムスタンプ引き継ぎを実装した。

## 変更内容
- `memo-toolbar.tsx` を新規作成（Bold / Italic / H2 / BulletList / Link ボタン）
- `memo-section.tsx`: ツールバーと Link 拡張を追加、過去メモのリッチ表示に対応
- `post-list.tsx`: リッチテキスト表示対応・タイムスタンプ表示とシーク機能を追加
- `lesson-content.tsx`: `PostList` に `seekTo` を渡すよう更新
- `posts` テーブルに `timestamp_seconds` カラムを追加（マイグレーション）
- `lib/db/posts.ts` / `api/posts/route.ts`: `timestamp_seconds` の保存・取得に対応
- `globals.css`: `.ProseMirror`（エディタ内）と `.rich-content`（表示用）のスタイルを追加
- `schema.md`: `posts` テーブルに `timestamp_seconds` を追記

## DBマイグレーション
Supabase ダッシュボードで以下を実行してください（開発・本番両方）。

```sql
alter table public.posts add column timestamp_seconds int default null;
```

## 確認事項
- [x] セルフレビュー済み