### PR TITLE
fix: コードブロック挿入時に言語セレクターを即時表示

### DIFF
--- a/src/components/lesson/memo-section.tsx
+++ b/src/components/lesson/memo-section.tsx
@@ -52,12 +52,13 @@ export default function MemoSection({ lessonId, getCurrentTime, seekTo, onClose 
   const [saveState, setSaveState] = useState<"idle" | "saving" | "saved">("idle");
   const [editorEmpty, setEditorEmpty] = useState(true);
   const [codeBlockLang, setCodeBlockLang] = useState<string>("");
+  const [isCodeBlockActive, setIsCodeBlockActive] = useState(false);
 
   const syncEditorState = (editor: Parameters<NonNullable<Parameters<typeof useEditor>[0]["onUpdate"]>>[0]["editor"]) => {
+    const active = editor.isActive("codeBlock");
     setEditorEmpty(editor.isEmpty);
-    setCodeBlockLang(
-      editor.isActive("codeBlock") ? (editor.getAttributes("codeBlock").language ?? "") : ""
-    );
+    setIsCodeBlockActive(active);
+    setCodeBlockLang(active ? (editor.getAttributes("codeBlock").language ?? "") : "");
   };
 
   const editor = useEditor({
@@ -171,7 +172,7 @@ export default function MemoSection({ lessonId, getCurrentTime, seekTo, onClose 
 
       {/* tiptap エディタ */}
       <div className="rounded-md border bg-background focus-within:ring-2 focus-within:ring-ring">
-        {editor && <MemoToolbar editor={editor} codeBlockLang={codeBlockLang} />}
+        {editor && <MemoToolbar editor={editor} codeBlockLang={codeBlockLang} isCodeBlockActive={isCodeBlockActive} />}
         <EditorContent editor={editor} />
       </div>
 

--- a/src/components/lesson/memo-toolbar.tsx
+++ b/src/components/lesson/memo-toolbar.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 type Props = {
   editor: Editor;
   codeBlockLang: string;
+  isCodeBlockActive: boolean;
 };
 
 type ToolbarButtonProps = {
@@ -35,7 +36,7 @@ function ToolbarButton({ onClick, isActive, title, children }: ToolbarButtonProp
   );
 }
 
-export default function MemoToolbar({ editor, codeBlockLang }: Props) {
+export default function MemoToolbar({ editor, codeBlockLang, isCodeBlockActive }: Props) {
   const [showLinkInput, setShowLinkInput] = useState(false);
   const [linkUrl, setLinkUrl] = useState("");
 
@@ -107,7 +108,7 @@ export default function MemoToolbar({ editor, codeBlockLang }: Props) {
         {"{ }"}
       </ToolbarButton>
 
-      {editor.isActive("codeBlock") && (
+      {isCodeBlockActive && (
         <select
           value={codeBlockLang}
           onChange={(e) =>


### PR DESCRIPTION
## 概要
コードブロックを挿入した時点で言語選択ドロップダウンが表示されるよう修正。

## 変更内容
- `MemoSection` に `isCodeBlockActive` state を追加
- `syncEditorState` 内で `editor.isActive("codeBlock")` の結果を state に反映
- `MemoToolbar` に `isCodeBlockActive` prop を渡し、ドロップダウンの表示条件をこの prop で判定するよう変更

## 確認事項
- [ ] セルフレビュー済み