### PR TITLE
feat: Phase 11 プロフィール編集機能

### DIFF
--- a/src/app/(student)/profile/page.tsx
+++ b/src/app/(student)/profile/page.tsx
@@ -1,0 +1,39 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import ProfileEditForm from "@/components/profile/profile-edit-form";
+
+export default async function ProfilePage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("display_name, student_number, note")
+    .eq("id", user.id)
+    .single();
+
+  if (!profile) redirect("/");
+
+  return (
+    <div className="max-w-lg mx-auto px-4 py-10">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold">プロフィール編集</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          表示名・学籍番号・備考を編集できます。
+        </p>
+      </div>
+
+      <div className="bg-card border rounded-xl p-6">
+        <ProfileEditForm
+          initialDisplayName={profile.display_name}
+          initialStudentNumber={profile.student_number}
+          initialNote={profile.note}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(student)/profile/page.tsx
+++ b/src/app/(student)/profile/page.tsx
@@ -12,7 +12,7 @@ export default async function ProfilePage() {
 
   const { data: profile } = await supabase
     .from("profiles")
-    .select("display_name, student_number, note")
+    .select("student_number, note")
     .eq("id", user.id)
     .single();
 
@@ -29,7 +29,6 @@ export default async function ProfilePage() {
 
       <div className="bg-card border rounded-xl p-6">
         <ProfileEditForm
-          initialDisplayName={profile.display_name}
           initialStudentNumber={profile.student_number}
           initialNote={profile.note}
         />

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+type UpdateProfileBody = {
+  targetUserId?: string; // teacher/admin が他ユーザーを更新する場合に指定
+  displayName?: string;
+  studentNumber?: number | null;
+  note?: string | null;
+};
+
+export async function PUT(req: Request) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: myProfile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  const body = (await req.json()) as UpdateProfileBody;
+  const targetUserId = body.targetUserId ?? user.id;
+
+  // 他ユーザーを更新しようとしている場合は teacher/admin のみ許可
+  if (targetUserId !== user.id) {
+    if (myProfile?.role !== "teacher" && myProfile?.role !== "admin") {
+      return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
+    }
+  }
+
+  const patch: Record<string, unknown> = {};
+  if (body.displayName !== undefined) patch.display_name = body.displayName;
+  if (body.studentNumber !== undefined) patch.student_number = body.studentNumber;
+  if (body.note !== undefined) patch.note = body.note;
+
+  if (Object.keys(patch).length === 0) {
+    return NextResponse.json({ data: null, error: "No fields to update" }, { status: 400 });
+  }
+
+  const { data, error } = await supabase
+    .from("profiles")
+    .update(patch)
+    .eq("id", targetUserId)
+    .select()
+    .single();
+
+  if (error || !data) {
+    return NextResponse.json({ data: null, error: "Failed to update profile" }, { status: 500 });
+  }
+
+  return NextResponse.json({ data, error: null });
+}

--- a/src/components/profile/profile-edit-form.tsx
+++ b/src/components/profile/profile-edit-form.tsx
@@ -4,19 +4,16 @@ import { useState } from "react";
 import { toast } from "sonner";
 
 type Props = {
-  initialDisplayName: string;
   initialStudentNumber: number | null;
   initialNote: string | null;
   targetUserId?: string; // teacher/admin が他ユーザーを編集する場合に指定
 };
 
 export default function ProfileEditForm({
-  initialDisplayName,
   initialStudentNumber,
   initialNote,
   targetUserId,
 }: Props) {
-  const [displayName, setDisplayName] = useState(initialDisplayName);
   const [studentNumber, setStudentNumber] = useState(
     initialStudentNumber !== null ? String(initialStudentNumber) : ""
   );
@@ -25,11 +22,6 @@ export default function ProfileEditForm({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!displayName.trim()) {
-      toast.error("表示名を入力してください");
-      return;
-    }
-
     const studentNumberParsed = studentNumber.trim()
       ? parseInt(studentNumber.trim(), 10)
       : null;
@@ -45,7 +37,6 @@ export default function ProfileEditForm({
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         ...(targetUserId ? { targetUserId } : {}),
-        displayName: displayName.trim(),
         studentNumber: studentNumberParsed,
         note: note.trim() || null,
       }),
@@ -61,17 +52,6 @@ export default function ProfileEditForm({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-5">
-      <div className="space-y-1">
-        <label className="text-sm font-medium">表示名</label>
-        <input
-          type="text"
-          value={displayName}
-          onChange={(e) => setDisplayName(e.target.value)}
-          placeholder="表示名を入力"
-          className="w-full border rounded-md px-3 py-2 text-sm bg-background focus:outline-none focus:ring-2 focus:ring-ring"
-        />
-      </div>
-
       <div className="space-y-1">
         <label className="text-sm font-medium">学籍番号</label>
         <input

--- a/src/components/profile/profile-edit-form.tsx
+++ b/src/components/profile/profile-edit-form.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+
+type Props = {
+  initialDisplayName: string;
+  initialStudentNumber: number | null;
+  initialNote: string | null;
+  targetUserId?: string; // teacher/admin が他ユーザーを編集する場合に指定
+};
+
+export default function ProfileEditForm({
+  initialDisplayName,
+  initialStudentNumber,
+  initialNote,
+  targetUserId,
+}: Props) {
+  const [displayName, setDisplayName] = useState(initialDisplayName);
+  const [studentNumber, setStudentNumber] = useState(
+    initialStudentNumber !== null ? String(initialStudentNumber) : ""
+  );
+  const [note, setNote] = useState(initialNote ?? "");
+  const [saving, setSaving] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!displayName.trim()) {
+      toast.error("表示名を入力してください");
+      return;
+    }
+
+    const studentNumberParsed = studentNumber.trim()
+      ? parseInt(studentNumber.trim(), 10)
+      : null;
+
+    if (studentNumber.trim() && isNaN(studentNumberParsed!)) {
+      toast.error("学籍番号は数字で入力してください");
+      return;
+    }
+
+    setSaving(true);
+    const res = await fetch("/api/profile", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...(targetUserId ? { targetUserId } : {}),
+        displayName: displayName.trim(),
+        studentNumber: studentNumberParsed,
+        note: note.trim() || null,
+      }),
+    });
+    setSaving(false);
+
+    if (res.ok) {
+      toast.success("プロフィールを保存しました");
+    } else {
+      toast.error("保存に失敗しました");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      <div className="space-y-1">
+        <label className="text-sm font-medium">表示名</label>
+        <input
+          type="text"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          placeholder="表示名を入力"
+          className="w-full border rounded-md px-3 py-2 text-sm bg-background focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+      </div>
+
+      <div className="space-y-1">
+        <label className="text-sm font-medium">学籍番号</label>
+        <input
+          type="text"
+          inputMode="numeric"
+          value={studentNumber}
+          onChange={(e) => setStudentNumber(e.target.value)}
+          placeholder="例: 12345"
+          className="w-full border rounded-md px-3 py-2 text-sm bg-background focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        <p className="text-xs text-muted-foreground">数字のみ入力してください</p>
+      </div>
+
+      <div className="space-y-1">
+        <label className="text-sm font-medium">備考</label>
+        <textarea
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="自由記述（省略可）"
+          rows={3}
+          className="w-full border rounded-md px-3 py-2 text-sm bg-background focus:outline-none focus:ring-2 focus:ring-ring resize-none"
+        />
+      </div>
+
+      <button
+        type="submit"
+        disabled={saving}
+        className="w-full py-2 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        {saving ? "保存中..." : "保存する"}
+      </button>
+    </form>
+  );
+}

--- a/src/components/shared/user-menu.tsx
+++ b/src/components/shared/user-menu.tsx
@@ -72,6 +72,10 @@ export default function UserMenu({ displayName, role }: Props) {
           </DropdownMenuItem>
         )}
         <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link href="/profile">プロフィール編集</Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
         <DropdownMenuItem
           onClick={handleLogout}
           className="text-destructive focus:text-destructive"

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -162,21 +162,27 @@ export type Database = {
           display_name: string
           id: string
           is_approved: boolean
+          note: string | null
           role: Database["public"]["Enums"]["role"]
+          student_number: number | null
         }
         Insert: {
           created_at?: string
           display_name?: string
           id: string
           is_approved?: boolean
+          note?: string | null
           role?: Database["public"]["Enums"]["role"]
+          student_number?: number | null
         }
         Update: {
           created_at?: string
           display_name?: string
           id?: string
           is_approved?: boolean
+          note?: string | null
           role?: Database["public"]["Enums"]["role"]
+          student_number?: number | null
         }
         Relationships: []
       }

--- a/supabase/migrations/20260316000001_profiles_add_student_fields.sql
+++ b/supabase/migrations/20260316000001_profiles_add_student_fields.sql
@@ -1,0 +1,4 @@
+-- profiles テーブルに学籍番号・備考を追加
+alter table public.profiles
+  add column student_number integer,
+  add column note text;


### PR DESCRIPTION
## 概要
生徒が学籍番号・備考を編集できるプロフィール編集機能を追加。表示名は編集不可とした。

## 変更内容
- `profiles` テーブルに `student_number`（integer）・`note`（text）カラムを追加するマイグレーション
- `src/lib/supabase/types.ts` に新カラムの型定義を追加
- `PUT /api/profile` を実装（本人 または teacher/admin が更新可能）
- プロフィール編集ページを追加（`/profile`）— 学籍番号・備考のみ編集可
- UserMenu に「プロフィール編集」リンクを追加

## 確認事項
- [x] セルフレビュー済み