### PR TITLE
feat: メモ一覧に授業ごとのYouTube URLを表示・Markdown出力に含める

### DIFF
--- a/src/app/(student)/memos/page.tsx
+++ b/src/app/(student)/memos/page.tsx
@@ -135,9 +135,9 @@ export default async function MemosPage() {
                                     href={lesson.youtube_url}
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    className="text-xs text-indigo-600 hover:underline block mb-3 break-all"
+                                    className="text-xs text-indigo-600 hover:underline block mb-3"
                                   >
-                                    {lesson.youtube_url}
+                                    動画
                                   </a>
                                 )}
                                 <div className="space-y-3 pl-4 border-l-2 border-indigo-100">

--- a/src/app/(student)/memos/page.tsx
+++ b/src/app/(student)/memos/page.tsx
@@ -85,6 +85,7 @@ export default async function MemosPage() {
               const subjectSections = subject.units.flatMap((unit) =>
                 unit.lessons.map((lesson) => ({
                   lessonTitle: lesson.title,
+                  youtubeUrl: lesson.youtube_url,
                   memos: lesson.memos,
                 }))
               );
@@ -101,6 +102,7 @@ export default async function MemosPage() {
                     {subject.units.map((unit) => {
                       const unitSections = unit.lessons.map((lesson) => ({
                         lessonTitle: lesson.title,
+                        youtubeUrl: lesson.youtube_url,
                         memos: lesson.memos,
                       }));
                       return (
@@ -122,11 +124,22 @@ export default async function MemosPage() {
                                     sections={[
                                       {
                                         lessonTitle: lesson.title,
+                                        youtubeUrl: lesson.youtube_url,
                                         memos: lesson.memos,
                                       },
                                     ]}
                                   />
                                 </div>
+                                {lesson.youtube_url && (
+                                  <a
+                                    href={lesson.youtube_url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-xs text-indigo-600 hover:underline block mb-3 break-all"
+                                  >
+                                    {lesson.youtube_url}
+                                  </a>
+                                )}
                                 <div className="space-y-3 pl-4 border-l-2 border-indigo-100">
                                   {lesson.memos.map((memo) => (
                                     <div

--- a/src/components/memos/memo-download-button.tsx
+++ b/src/components/memos/memo-download-button.tsx
@@ -31,6 +31,7 @@ type MemoData = {
 
 export type MemoSection = {
   lessonTitle: string;
+  youtubeUrl: string | null;
   memos: MemoData[];
 };
 
@@ -47,6 +48,9 @@ export default function MemoDownloadButton({ filename, sections }: Props) {
     const parts: string[] = [];
     for (const section of sections) {
       parts.push(`## ${section.lessonTitle}\n`);
+      if (section.youtubeUrl) {
+        parts.push(`${section.youtubeUrl}\n`);
+      }
       for (const memo of section.memos) {
         if (memo.timestamp_seconds !== null) {
           parts.push(`> ⏱ ${formatTime(memo.timestamp_seconds)}\n`);

--- a/src/components/memos/memo-download-button.tsx
+++ b/src/components/memos/memo-download-button.tsx
@@ -49,7 +49,7 @@ export default function MemoDownloadButton({ filename, sections }: Props) {
     for (const section of sections) {
       parts.push(`## ${section.lessonTitle}\n`);
       if (section.youtubeUrl) {
-        parts.push(`${section.youtubeUrl}\n`);
+        parts.push(`[動画](${section.youtubeUrl})\n`);
       }
       for (const memo of section.memos) {
         if (memo.timestamp_seconds !== null) {


### PR DESCRIPTION
## 概要
メモ一覧ページの各授業に YouTube 動画リンクを追加し、Markdown ダウンロード時にも含めるようにした。

## 変更内容
- `app/(student)/memos/page.tsx`: 授業タイトルの下に「動画」リンクを表示（`youtube_url` がある場合）
- `components/memos/memo-download-button.tsx`: `MemoSection` に `youtubeUrl` を追加し、Markdown 出力時に `[動画](url)` 形式で授業タイトルの直下に挿入

## 確認事項
- [x] セルフレビュー済み