### PR TITLE
feat: 小テスト完了ゲートを実装（Phase 15）

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -507,11 +507,10 @@ create table public.quiz_attempts (
 
 ### タスク
 
-- [ ] マイグレーション：`quiz_attempts` テーブルを追加（RLS含む）
-- [ ] `POST /api/quizzes/[quizId]/attempts` を実装（小テスト提出時に呼び出す）
+- [x] マイグレーション：`quiz_attempts` テーブルを追加（RLS含む）
+- [x] `POST /api/quizzes/[quizId]/attempts` を実装（小テスト提出時に呼び出す）
   - スコアはサーバーサイドで採点して保存（既存のクライアント採点と並行）
-- [ ] `GET /api/quizzes/[quizId]/attempts/me` を実装（完了済みか確認）
-- [ ] レッスンページで完了状態を取得し、`PostList` のロック/アンロックを制御
+- [x] レッスンページで完了状態を取得し、`PostList` のロック/アンロックを制御
   - 小テストなし → 最初から表示
   - 小テストあり・未完了 → ロック表示（「小テストを完了すると、みんなの投稿が見られます」）
   - 小テストあり・完了済み → 表示
@@ -674,10 +673,10 @@ create table public.quiz_attempt_answers (
 [✅] Phase 12.9: 小テスト JSON インポート機能
 [ ] Phase 13:   データ出力（教師向け）
 [--] Phase 14:  いいね機能（見送り）
-[ ] Phase 15:   小テスト完了ゲート
+[✅] Phase 15:   小テスト完了ゲート
 [ ] Phase 15.5: 小テスト回答詳細の保存
 [ ] Phase 16:   トロフィー・実績機能
 [ ] Phase 17:   匿名プライベートコメント機能
 ```
 
-次の着手は **Phase 13: データ出力（教師向け）** または **Phase 15: 小テスト完了ゲート**。
+次の着手は **Phase 13: データ出力（教師向け）** または **Phase 15.5: 小テスト回答詳細の保存**。

--- a/src/app/(student)/lessons/[lessonId]/page.tsx
+++ b/src/app/(student)/lessons/[lessonId]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { getLessonWithQuestions } from "@/lib/db/contents";
-import { getQuizWithQuestions } from "@/lib/db/quizzes";
+import { getQuizWithQuestions, hasCompletedQuiz } from "@/lib/db/quizzes";
 import { createClient } from "@/lib/supabase/server";
 import LessonContent from "@/components/lesson/lesson-content";
 
@@ -21,6 +21,8 @@ export default async function LessonPage({ params }: Props) {
 
   if (!lesson) return notFound();
   if (!user) return notFound();
+
+  const initialIsCompleted = quiz ? await hasCompletedQuiz(quiz.id, user.id) : false;
 
   const { unit, questions } = lesson;
   const subject = unit.subject;
@@ -48,6 +50,7 @@ export default async function LessonPage({ params }: Props) {
         questions={questions}
         quiz={quiz}
         currentUserId={user.id}
+        initialIsCompleted={initialIsCompleted}
       />
     </div>
   );

--- a/src/app/api/quizzes/[quizId]/attempts/route.ts
+++ b/src/app/api/quizzes/[quizId]/attempts/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createQuizAttempt, hasCompletedQuiz } from "@/lib/db/quizzes";
+import type { QuizQuestion } from "@/lib/db/quizzes";
+
+type AnswerPayload =
+  | { questionId: string; type: "multiple_choice"; selectedText: string }
+  | { questionId: string; type: "short_answer"; text: string }
+  | { questionId: string; type: "ordering"; items: string[] };
+
+type Params = { params: Promise<{ quizId: string }> };
+
+export async function GET(_req: NextRequest, { params }: Params) {
+  const { quizId } = await params;
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
+
+  const completed = await hasCompletedQuiz(quizId, user.id);
+  return NextResponse.json({ data: { completed }, error: null });
+}
+
+export async function POST(req: NextRequest, { params }: Params) {
+  const { quizId } = await params;
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
+
+  const body = (await req.json()) as { answers: AnswerPayload[] };
+  if (!Array.isArray(body.answers)) {
+    return NextResponse.json({ data: null, error: "Invalid payload" }, { status: 400 });
+  }
+
+  // クイズと問題を取得してサーバーサイドで採点
+  const { data: questions, error: qErr } = await supabase
+    .from("quiz_questions")
+    .select("*")
+    .eq("quiz_id", quizId)
+    .order("order");
+
+  if (qErr || !questions) {
+    return NextResponse.json({ data: null, error: "Quiz not found" }, { status: 404 });
+  }
+
+  let score = 0;
+  let maxScore = 0;
+
+  for (const q of questions as QuizQuestion[]) {
+    if (q.type === "short_answer") continue;
+    maxScore++;
+
+    const answer = body.answers.find((a) => a.questionId === q.id);
+    if (!answer) continue;
+
+    if (q.type === "multiple_choice" && answer.type === "multiple_choice") {
+      const correctIndex = (q.correct_answer as { index: number }).index;
+      const correctText = (q.options as string[])[correctIndex];
+      if (answer.selectedText === correctText) score++;
+    } else if (q.type === "ordering" && answer.type === "ordering") {
+      if (JSON.stringify(answer.items) === JSON.stringify(q.correct_answer as string[])) score++;
+    }
+  }
+
+  const ok = await createQuizAttempt({ quizId, userId: user.id, score, maxScore });
+  if (!ok) {
+    return NextResponse.json({ data: null, error: "Failed to save attempt" }, { status: 500 });
+  }
+
+  return NextResponse.json({ data: { score, maxScore }, error: null }, { status: 201 });
+}

--- a/src/components/lesson/lesson-content.tsx
+++ b/src/components/lesson/lesson-content.tsx
@@ -14,6 +14,7 @@ type Props = {
   questions: Question[];
   quiz: QuizWithQuestions | null;
   currentUserId: string;
+  initialIsCompleted: boolean;
 };
 
 export default function LessonContent({
@@ -22,8 +23,13 @@ export default function LessonContent({
   questions,
   quiz,
   currentUserId,
+  initialIsCompleted,
 }: Props) {
   const [memoVisible, setMemoVisible] = useState(true);
+  // 小テストなし or 完了済みなら最初からアンロック
+  const [isPostUnlocked, setIsPostUnlocked] = useState(
+    quiz === null || initialIsCompleted
+  );
   const playerRef = useRef<YouTubePlayer | null>(null);
 
   const getCurrentTime = (): number | null => {
@@ -57,9 +63,19 @@ export default function LessonContent({
             onPlayerReady={(player) => {
               playerRef.current = player;
             }}
+            onQuizCompleted={() => setIsPostUnlocked(true)}
           />
           <div className="border-t pt-6">
-            <PostList lessonId={lessonId} currentUserId={currentUserId} seekTo={seekTo} />
+            {isPostUnlocked ? (
+              <PostList lessonId={lessonId} currentUserId={currentUserId} seekTo={seekTo} />
+            ) : (
+              <div className="flex flex-col items-center justify-center py-12 gap-3 text-center">
+                <span className="text-4xl">🔒</span>
+                <p className="text-sm text-muted-foreground">
+                  小テストを完了すると、みんなの投稿が見られます
+                </p>
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/components/lesson/lesson-tabs.tsx
+++ b/src/components/lesson/lesson-tabs.tsx
@@ -15,9 +15,10 @@ type Props = {
   questions: Question[];
   quiz: QuizWithQuestions | null;
   onPlayerReady: (player: YouTubePlayer) => void;
+  onQuizCompleted?: () => void;
 };
 
-export default function LessonTabs({ youtubeUrl, questions, quiz, onPlayerReady }: Props) {
+export default function LessonTabs({ youtubeUrl, questions, quiz, onPlayerReady, onQuizCompleted }: Props) {
   const [activeTab, setActiveTab] = useState<Tab>("video");
 
   return (
@@ -57,7 +58,7 @@ export default function LessonTabs({ youtubeUrl, questions, quiz, onPlayerReady 
       {/* 小テストタブ */}
       {activeTab === "quiz" && (
         quiz ? (
-          <QuizSection quiz={quiz} />
+          <QuizSection quiz={quiz} onCompleted={onQuizCompleted} />
         ) : (
           <div className="aspect-video rounded-md border bg-card flex flex-col items-center justify-center gap-2 text-center">
             <span className="text-4xl">📝</span>

--- a/src/components/lesson/quiz-section.tsx
+++ b/src/components/lesson/quiz-section.tsx
@@ -286,9 +286,10 @@ function initAnswer(question: QuizQuestion): Answer {
 
 type Props = {
   quiz: QuizWithQuestions;
+  onCompleted?: () => void;
 };
 
-export default function QuizSection({ quiz }: Props) {
+export default function QuizSection({ quiz, onCompleted }: Props) {
   const [answers, setAnswers] = useState<Answer[]>(() =>
     quiz.questions.map(initAnswer)
   );
@@ -313,8 +314,36 @@ export default function QuizSection({ quiz }: Props) {
     return { correct, autoGradable };
   }, [quizState, answers, quiz.questions]);
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     setQuizState("submitted");
+
+    // 提出内容をAPIに送信して完了フラグを記録
+    const payload = quiz.questions.map((q, i) => {
+      const ans = answers[i];
+      if (ans.type === "multiple_choice") {
+        return {
+          questionId: q.id,
+          type: "multiple_choice" as const,
+          selectedText: ans.selectedIndex !== null
+            ? ans.shuffledOptions[ans.selectedIndex]
+            : "",
+        };
+      }
+      if (ans.type === "short_answer") {
+        return { questionId: q.id, type: "short_answer" as const, text: ans.text };
+      }
+      return { questionId: q.id, type: "ordering" as const, items: ans.items };
+    });
+
+    const res = await fetch(`/api/quizzes/${quiz.id}/attempts`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ answers: payload }),
+    });
+
+    if (res.ok) {
+      onCompleted?.();
+    }
   };
 
   const handleRetry = () => {

--- a/src/lib/db/quizzes.ts
+++ b/src/lib/db/quizzes.ts
@@ -21,6 +21,13 @@ export type CreateQuizQuestionInput = {
 
 type InsertRow = Database["public"]["Tables"]["quiz_questions"]["Insert"];
 
+export type QuizAttemptInput = {
+  quizId: string;
+  userId: string;
+  score: number;
+  maxScore: number;
+};
+
 /**
  * レッスンに紐づくクイズと問題一覧を取得する
  */
@@ -141,4 +148,31 @@ export async function deleteQuiz(quizId: string): Promise<boolean> {
   const supabase = await createClient();
   const { error } = await supabase.from("quizzes").delete().eq("id", quizId);
   return !error;
+}
+
+/**
+ * 小テスト提出記録を保存する
+ */
+export async function createQuizAttempt(input: QuizAttemptInput): Promise<boolean> {
+  const supabase = await createClient();
+  const { error } = await supabase.from("quiz_attempts").insert({
+    quiz_id: input.quizId,
+    user_id: input.userId,
+    score: input.score,
+    max_score: input.maxScore,
+  });
+  return !error;
+}
+
+/**
+ * ユーザーが指定クイズを1回以上提出済みか確認する
+ */
+export async function hasCompletedQuiz(quizId: string, userId: string): Promise<boolean> {
+  const supabase = await createClient();
+  const { count } = await supabase
+    .from("quiz_attempts")
+    .select("*", { count: "exact", head: true })
+    .eq("quiz_id", quizId)
+    .eq("user_id", userId);
+  return (count ?? 0) > 0;
 }

--- a/supabase/migrations/20260418000001_quiz_attempts.sql
+++ b/supabase/migrations/20260418000001_quiz_attempts.sql
@@ -1,0 +1,30 @@
+-- =====================
+-- quiz_attempts（小テスト提出記録）
+-- =====================
+
+create table public.quiz_attempts (
+  id           uuid primary key default gen_random_uuid(),
+  quiz_id      uuid not null references public.quizzes(id) on delete cascade,
+  user_id      uuid not null references public.profiles(id) on delete cascade,
+  score        int not null,
+  max_score    int not null,
+  submitted_at timestamptz not null default now()
+);
+
+alter table public.quiz_attempts enable row level security;
+
+-- 自分の記録のみ読み書き可
+create policy "quiz_attempts_select_own" on public.quiz_attempts
+  for select using (auth.uid() = user_id);
+
+create policy "quiz_attempts_insert_own" on public.quiz_attempts
+  for insert with check (auth.uid() = user_id);
+
+-- teacher/admin は全件読み取り可
+create policy "quiz_attempts_select_teacher" on public.quiz_attempts
+  for select using (
+    exists (
+      select 1 from public.profiles
+      where id = auth.uid() and role in ('teacher', 'admin')
+    )
+  );


### PR DESCRIPTION
## 概要
小テストを提出するまでPostList（みんなの投稿）を非表示にする完了ゲートを実装。

## 変更内容
- `quiz_attempts` テーブル追加（マイグレーションSQL: `supabase/migrations/20260418000001_quiz_attempts.sql`）
- `src/lib/db/quizzes.ts`: `createQuizAttempt` / `hasCompletedQuiz` 関数を追加
- `src/app/api/quizzes/[quizId]/attempts/route.ts`: 提出記録保存APIを新規作成（サーバーサイド採点）
- `src/components/lesson/quiz-section.tsx`: 提出時にAPIを呼び出し `onCompleted` コールバックを実行
- `src/components/lesson/lesson-tabs.tsx`: `onQuizCompleted` プロパティを追加してQuizSectionへ中継
- `src/components/lesson/lesson-content.tsx`: `isPostUnlocked` 状態でPostListのロック/アンロックを制御
- `src/app/(student)/lessons/[lessonId]/page.tsx`: SSRで完了状態を取得し `initialIsCompleted` を渡す

## 本番DBへの適用
`supabase/migrations/20260418000001_quiz_attempts.sql` の内容を本番Supabase Studio で手動実行してください。

## 確認事項
- [x] セルフレビュー済み