### PR TITLE
feat: teacher/admin による全投稿削除機能を追加

### DIFF
--- a/src/app/(student)/lessons/[lessonId]/page.tsx
+++ b/src/app/(student)/lessons/[lessonId]/page.tsx
@@ -22,7 +22,11 @@ export default async function LessonPage({ params }: Props) {
   if (!lesson) return notFound();
   if (!user) return notFound();
 
-  const initialIsCompleted = quiz ? await hasCompletedQuiz(quiz.id, user.id) : false;
+  const [initialIsCompleted, profileResult] = await Promise.all([
+    quiz ? hasCompletedQuiz(quiz.id, user.id) : Promise.resolve(false),
+    supabase.from("profiles").select("role").eq("id", user.id).single(),
+  ]);
+  const currentUserRole = profileResult.data?.role ?? "student";
 
   const { unit, questions } = lesson;
   const subject = unit.subject;
@@ -50,6 +54,7 @@ export default async function LessonPage({ params }: Props) {
         questions={questions}
         quiz={quiz}
         currentUserId={user.id}
+        currentUserRole={currentUserRole}
         initialIsCompleted={initialIsCompleted}
       />
     </div>

--- a/src/app/api/posts/[postId]/route.ts
+++ b/src/app/api/posts/[postId]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
 import { deletePost } from "@/lib/db/posts";
 
 export async function DELETE(
@@ -6,6 +7,9 @@ export async function DELETE(
   { params }: { params: Promise<{ postId: string }> }
 ) {
   const { postId } = await params;
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
 
   const success = await deletePost(postId);
   if (!success) {

--- a/src/components/lesson/lesson-content.tsx
+++ b/src/components/lesson/lesson-content.tsx
@@ -14,6 +14,7 @@ type Props = {
   questions: Question[];
   quiz: QuizWithQuestions | null;
   currentUserId: string;
+  currentUserRole: string;
   initialIsCompleted: boolean;
 };
 
@@ -23,6 +24,7 @@ export default function LessonContent({
   questions,
   quiz,
   currentUserId,
+  currentUserRole,
   initialIsCompleted,
 }: Props) {
   const [memoVisible, setMemoVisible] = useState(true);
@@ -67,7 +69,7 @@ export default function LessonContent({
           />
           <div className="border-t pt-6">
             {isPostUnlocked ? (
-              <PostList lessonId={lessonId} currentUserId={currentUserId} seekTo={seekTo} />
+              <PostList lessonId={lessonId} currentUserId={currentUserId} currentUserRole={currentUserRole} seekTo={seekTo} />
             ) : (
               <div className="flex flex-col items-center justify-center py-12 gap-3 text-center">
                 <span className="text-4xl">🔒</span>

--- a/src/components/lesson/post-list.tsx
+++ b/src/components/lesson/post-list.tsx
@@ -8,6 +8,7 @@ import RichContent from "@/components/shared/rich-content";
 type Props = {
   lessonId: string;
   currentUserId: string;
+  currentUserRole: string;
   seekTo: (seconds: number) => void;
 };
 
@@ -26,7 +27,8 @@ function formatDate(dateString: string): string {
   });
 }
 
-export default function PostList({ lessonId, currentUserId, seekTo }: Props) {
+export default function PostList({ lessonId, currentUserId, currentUserRole, seekTo }: Props) {
+  const isTeacherOrAdmin = currentUserRole === "teacher" || currentUserRole === "admin";
   const [posts, setPosts] = useState<Post[]>([]);
 
   useEffect(() => {
@@ -101,6 +103,7 @@ export default function PostList({ lessonId, currentUserId, seekTo }: Props) {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           {posts.map((post) => {
             const isMyPost = post.user_id === currentUserId;
+            const canDelete = isMyPost || isTeacherOrAdmin;
             return (
               <div
                 key={post.id}
@@ -110,10 +113,10 @@ export default function PostList({ lessonId, currentUserId, seekTo }: Props) {
                   {isMyPost && (
                     <p className="text-xs text-primary font-medium">自分の投稿</p>
                   )}
-                  {isMyPost && (
+                  {canDelete && (
                     <button
                       onClick={() => handleDelete(post.id)}
-                      className="text-xs px-2 py-0.5 rounded border border-destructive/30 text-destructive hover:bg-destructive/10 transition-colors shrink-0"
+                      className="text-xs px-2 py-0.5 rounded border border-destructive/30 text-destructive hover:bg-destructive/10 transition-colors shrink-0 ml-auto"
                     >
                       削除
                     </button>

--- a/supabase/migrations/20260418000002_posts_teacher_delete_policy.sql
+++ b/supabase/migrations/20260418000002_posts_teacher_delete_policy.sql
@@ -1,0 +1,9 @@
+-- teacher/admin は全件削除可
+CREATE POLICY "posts: teacher/admin 全件削除"
+  ON public.posts FOR DELETE
+  USING (
+    exists (
+      select 1 from public.profiles
+      where id = auth.uid() and role in ('teacher', 'admin')
+    )
+  );


### PR DESCRIPTION
## 概要
teacher/admin アカウントが不適切な投稿を削除できる機能を追加。student は引き続き自分の投稿のみ削除可能。

## 変更内容
- `supabase/migrations/20260418000002_posts_teacher_delete_policy.sql`: teacher/admin の posts DELETE RLS ポリシーを追加
- `src/app/api/posts/[postId]/route.ts`: 未認証リクエストを弾く認証チェックを追加
- `src/components/lesson/post-list.tsx`: `currentUserRole` を受け取り、teacher/admin は全投稿に削除ボタンを表示
- `src/components/lesson/lesson-content.tsx`: `currentUserRole` prop を追加して PostList に中継
- `src/app/(student)/lessons/[lessonId]/page.tsx`: profiles テーブルから role を取得して LessonContent に渡す

## 本番DBへの適用
`supabase/migrations/20260418000002_posts_teacher_delete_policy.sql` の内容を本番 Supabase Studio で手動実行してください。

## 確認事項
- [x] セルフレビュー済み