### PR TITLE
fix: teacher/admin の投稿閲覧制限解除と投稿者ツールチップを追加

### DIFF
--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,11 +1,33 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { getPostsByLessonId, createPost, existsPostByMemoId } from "@/lib/db/posts";
+import { createClient } from "@/lib/supabase/server";
+import {
+  getPostsByLessonId,
+  getPostsWithAuthorsByLessonId,
+  createPost,
+  existsPostByMemoId,
+} from "@/lib/db/posts";
 import type { TiptapContent } from "@/lib/db/memos";
 
 export async function GET(request: NextRequest) {
   const lessonId = request.nextUrl.searchParams.get("lessonId");
   if (!lessonId) {
     return NextResponse.json({ data: null, error: "lessonId is required" }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (user) {
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("role")
+      .eq("id", user.id)
+      .single();
+
+    if (profile?.role === "teacher" || profile?.role === "admin") {
+      const data = await getPostsWithAuthorsByLessonId(lessonId);
+      return NextResponse.json({ data, error: null });
+    }
   }
 
   const data = await getPostsByLessonId(lessonId);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import NavBar from "@/components/shared/nav-bar";
 import { Toaster } from "@/components/ui/sonner";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import NextTopLoader from "nextjs-toploader";
 
 const geistSans = Geist({
@@ -31,9 +32,11 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen bg-background`}
       >
         <NextTopLoader color="#6366f1" showSpinner={false} />
-        <NavBar />
-        <main>{children}</main>
-        <Toaster />
+        <TooltipProvider>
+          <NavBar />
+          <main>{children}</main>
+          <Toaster />
+        </TooltipProvider>
       </body>
     </html>
   );

--- a/src/components/lesson/lesson-content.tsx
+++ b/src/components/lesson/lesson-content.tsx
@@ -28,9 +28,10 @@ export default function LessonContent({
   initialIsCompleted,
 }: Props) {
   const [memoVisible, setMemoVisible] = useState(true);
-  // 小テストなし or 完了済みなら最初からアンロック
+  const isTeacherOrAdmin = currentUserRole === "teacher" || currentUserRole === "admin";
+  // 小テストなし or 完了済み or teacher/admin なら最初からアンロック
   const [isPostUnlocked, setIsPostUnlocked] = useState(
-    quiz === null || initialIsCompleted
+    quiz === null || initialIsCompleted || isTeacherOrAdmin
   );
   const playerRef = useRef<YouTubePlayer | null>(null);
 

--- a/src/components/lesson/post-list.tsx
+++ b/src/components/lesson/post-list.tsx
@@ -2,8 +2,10 @@
 
 import { useState, useEffect } from "react";
 import { createClient } from "@/lib/supabase/client";
-import type { Post } from "@/lib/db/posts";
+import type { Post, AuthorProfile } from "@/lib/db/posts";
 import RichContent from "@/components/shared/rich-content";
+
+type PostItem = Post & { authorProfile?: AuthorProfile };
 
 type Props = {
   lessonId: string;
@@ -27,14 +29,31 @@ function formatDate(dateString: string): string {
   });
 }
 
+function AuthorTooltip({ profile }: { profile: AuthorProfile }) {
+  const label = profile.student_number
+    ? `${profile.student_number} - ${profile.display_name}`
+    : profile.display_name;
+
+  return (
+    <div className="relative group/tooltip inline-flex items-center">
+      <span className="text-xs text-muted-foreground/60 cursor-default select-none">👤</span>
+      <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 hidden group-hover/tooltip:block z-10 pointer-events-none">
+        <div className="whitespace-nowrap rounded bg-foreground px-2 py-1 text-xs text-background shadow-md">
+          {label}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function PostList({ lessonId, currentUserId, currentUserRole, seekTo }: Props) {
   const isTeacherOrAdmin = currentUserRole === "teacher" || currentUserRole === "admin";
-  const [posts, setPosts] = useState<Post[]>([]);
+  const [posts, setPosts] = useState<PostItem[]>([]);
 
   useEffect(() => {
     fetch(`/api/posts?lessonId=${lessonId}`)
       .then((res) => res.json())
-      .then((json: { data: Post[] | null; error: string | null }) => {
+      .then((json: { data: PostItem[] | null; error: string | null }) => {
         if (json.data) setPosts(json.data);
       })
       .catch(() => {});
@@ -51,7 +70,7 @@ export default function PostList({ lessonId, currentUserId, currentUserRole, see
           filter: `lesson_id=eq.${lessonId}`,
         },
         (payload) => {
-          setPosts((prev) => [payload.new as Post, ...prev]);
+          setPosts((prev) => [payload.new as PostItem, ...prev]);
         }
       )
       .on(
@@ -109,14 +128,19 @@ export default function PostList({ lessonId, currentUserId, currentUserRole, see
                 key={post.id}
                 className={`p-4 rounded-lg border bg-card ${isMyPost ? "border-primary/40" : ""}`}
               >
-                <div className="flex items-start justify-between gap-2">
-                  {isMyPost && (
-                    <p className="text-xs text-primary font-medium">自分の投稿</p>
-                  )}
+                <div className="flex items-center justify-between gap-2 mb-1">
+                  <div className="flex items-center gap-1.5">
+                    {isMyPost && (
+                      <p className="text-xs text-primary font-medium">自分の投稿</p>
+                    )}
+                    {isTeacherOrAdmin && post.authorProfile && (
+                      <AuthorTooltip profile={post.authorProfile} />
+                    )}
+                  </div>
                   {canDelete && (
                     <button
                       onClick={() => handleDelete(post.id)}
-                      className="text-xs px-2 py-0.5 rounded border border-destructive/30 text-destructive hover:bg-destructive/10 transition-colors shrink-0 ml-auto"
+                      className="text-xs px-2 py-0.5 rounded border border-destructive/30 text-destructive hover:bg-destructive/10 transition-colors shrink-0"
                     >
                       削除
                     </button>

--- a/src/components/lesson/post-list.tsx
+++ b/src/components/lesson/post-list.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { createClient } from "@/lib/supabase/client";
 import type { Post, AuthorProfile } from "@/lib/db/posts";
 import RichContent from "@/components/shared/rich-content";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
 type PostItem = Post & { authorProfile?: AuthorProfile };
 
@@ -35,14 +36,12 @@ function AuthorTooltip({ profile }: { profile: AuthorProfile }) {
     : profile.display_name;
 
   return (
-    <div className="relative group/tooltip inline-flex items-center">
-      <span className="text-xs text-muted-foreground/60 cursor-default select-none">👤</span>
-      <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 hidden group-hover/tooltip:block z-10 pointer-events-none">
-        <div className="whitespace-nowrap rounded bg-foreground px-2 py-1 text-xs text-background shadow-md">
-          {label}
-        </div>
-      </div>
-    </div>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="text-xs text-muted-foreground/60 cursor-default select-none">👤</span>
+      </TooltipTrigger>
+      <TooltipContent side="top">{label}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import * as React from "react"
+import { Tooltip as TooltipPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/src/lib/db/posts.ts
+++ b/src/lib/db/posts.ts
@@ -7,6 +7,13 @@ export type Post = Omit<Database["public"]["Tables"]["posts"]["Row"], "content">
   timestamp_seconds: number | null;
 };
 
+export type AuthorProfile = {
+  student_number: number | null;
+  display_name: string;
+};
+
+export type PostWithAuthor = Post & { authorProfile: AuthorProfile };
+
 /**
  * 指定レッスンの投稿一覧を取得する（全認証ユーザーが閲覧可）
  */
@@ -21,6 +28,29 @@ export async function getPostsByLessonId(lessonId: string): Promise<Post[]> {
 
   if (error || !data) return [];
   return data as Post[];
+}
+
+/**
+ * 指定レッスンの投稿一覧を投稿者プロフィール付きで取得する（teacher/admin 用）
+ */
+export async function getPostsWithAuthorsByLessonId(lessonId: string): Promise<PostWithAuthor[]> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("posts")
+    .select("*, profiles(student_number, display_name)")
+    .eq("lesson_id", lessonId)
+    .order("created_at", { ascending: false });
+
+  if (error || !data) return [];
+
+  return data.map((row) => {
+    const { profiles, ...post } = row as typeof row & { profiles: AuthorProfile | null };
+    return {
+      ...(post as Post),
+      authorProfile: profiles ?? { student_number: null, display_name: "不明" },
+    };
+  });
 }
 
 /**


### PR DESCRIPTION
## 概要
Phase 15 の小テスト完了ゲートに対する追加修正。teacher/admin が投稿を常に閲覧・管理できるよう対応。

## 変更内容
- `src/components/lesson/lesson-content.tsx`: teacher/admin は `isPostUnlocked` を常に `true` で初期化（小テスト未完了でも投稿一覧を表示）
- `src/lib/db/posts.ts`: `AuthorProfile` / `PostWithAuthor` 型と `getPostsWithAuthorsByLessonId()` 関数を追加
- `src/app/api/posts/route.ts`: teacher/admin のリクエスト時は profiles を JOIN して `authorProfile` を付与して返す
- `src/components/lesson/post-list.tsx`: teacher/admin には各投稿カードに 👤 アイコンを表示、ホバーで「学籍番号 - 表示名」のツールチップを表示

## 確認事項
- [ ] セルフレビュー済み