### PR TITLE
chore: .gitignoreの誤記を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
-NEXT_PUBLIC_SUPABASE_URL=
+
+# supabase studio snippets (auto-synced, not part of codebase)
+/supabase/snippets/


### PR DESCRIPTION
## 概要
.gitignore の誤記を修正。

## 変更内容
- `NEXT_PUBLIC_SUPABASE_URL=` という不正な行を削除（環境変数の値が誤って混入していた）
- `/supabase/snippets/` の除外設定を再追加（マージ時に消えていた）

## 確認事項
- [x] セルフレビュー済み