### PR TITLE
fix: 生徒メモ閲覧の絞り込みを学年・クラス単独指定に対応しロードボタンを追加

### DIFF
--- a/src/app/api/teacher/lessons/[lessonId]/memo-students/route.ts
+++ b/src/app/api/teacher/lessons/[lessonId]/memo-students/route.ts
@@ -25,11 +25,22 @@ export async function GET(req: NextRequest, { params }: Params) {
   }
 
   const { searchParams } = req.nextUrl;
-  const grade = parseInt(searchParams.get("grade") ?? "", 10);
-  const classNum = parseInt(searchParams.get("class") ?? "", 10);
+  const gradeRaw = searchParams.get("grade");
+  const classRaw = searchParams.get("class");
+  const grade = gradeRaw !== null ? parseInt(gradeRaw, 10) : null;
+  const classNum = classRaw !== null ? parseInt(classRaw, 10) : null;
 
-  if (isNaN(grade) || isNaN(classNum)) {
-    return NextResponse.json({ data: null, error: "grade and class are required" }, { status: 400 });
+  if (grade === null && classNum === null) {
+    return NextResponse.json(
+      { data: null, error: "grade または class のどちらかは必須です" },
+      { status: 400 }
+    );
+  }
+  if (grade !== null && isNaN(grade)) {
+    return NextResponse.json({ data: null, error: "grade is invalid" }, { status: 400 });
+  }
+  if (classNum !== null && isNaN(classNum)) {
+    return NextResponse.json({ data: null, error: "class is invalid" }, { status: 400 });
   }
 
   const students = await getStudentsWithMemoCounts(lessonId, grade, classNum);

--- a/src/components/teacher/student-memo-viewer.tsx
+++ b/src/components/teacher/student-memo-viewer.tsx
@@ -18,27 +18,23 @@ export default function StudentMemoViewer({ lessonId }: Props) {
   const [memosByUser, setMemosByUser] = useState<Record<string, Memo[]>>({});
   const [loadingMemoUserId, setLoadingMemoUserId] = useState<string | null>(null);
 
-  const handleSearch = async (g: number, c: number) => {
+  const canLoad = grade !== null || classNum !== null;
+
+  const handleLoad = async () => {
+    if (!canLoad) return;
     setStudents(null);
     setExpandedUserId(null);
     setMemosByUser({});
     setLoadingStudents(true);
+    const params = new URLSearchParams();
+    if (grade !== null) params.set("grade", String(grade));
+    if (classNum !== null) params.set("class", String(classNum));
     const res = await fetch(
-      `/api/teacher/lessons/${lessonId}/memo-students?grade=${g}&class=${c}`
+      `/api/teacher/lessons/${lessonId}/memo-students?${params.toString()}`
     );
     const json = (await res.json()) as { data: StudentWithMemoCount[] | null; error: string | null };
     setStudents(json.data ?? []);
     setLoadingStudents(false);
-  };
-
-  const handleGradeChange = (value: number) => {
-    setGrade(value);
-    if (classNum !== null) handleSearch(value, classNum);
-  };
-
-  const handleClassChange = (value: number) => {
-    setClassNum(value);
-    if (grade !== null) handleSearch(grade, value);
   };
 
   const handleToggleStudent = async (userId: string, memoCount: number) => {
@@ -61,15 +57,15 @@ export default function StudentMemoViewer({ lessonId }: Props) {
   return (
     <div className="space-y-6">
       {/* 学年・クラス選択 */}
-      <div className="flex items-center gap-4 p-4 rounded-md border bg-muted/30">
+      <div className="flex flex-wrap items-center gap-4 p-4 rounded-md border bg-muted/30">
         <div className="flex items-center gap-2">
           <label className="text-sm font-medium">学年</label>
           <select
             className="px-3 py-1.5 rounded-md border bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
             value={grade ?? ""}
-            onChange={(e) => handleGradeChange(Number(e.target.value))}
+            onChange={(e) => setGrade(e.target.value === "" ? null : Number(e.target.value))}
           >
-            <option value="" disabled>選択</option>
+            <option value="">指定なし</option>
             {GRADES.map((g) => (
               <option key={g} value={g}>{g}年</option>
             ))}
@@ -80,19 +76,21 @@ export default function StudentMemoViewer({ lessonId }: Props) {
           <select
             className="px-3 py-1.5 rounded-md border bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
             value={classNum ?? ""}
-            onChange={(e) => handleClassChange(Number(e.target.value))}
+            onChange={(e) => setClassNum(e.target.value === "" ? null : Number(e.target.value))}
           >
-            <option value="" disabled>選択</option>
+            <option value="">指定なし</option>
             {CLASSES.map((c) => (
               <option key={c} value={c}>{c}組</option>
             ))}
           </select>
         </div>
-        {grade !== null && classNum !== null && (
-          <span className="text-sm text-muted-foreground">
-            {grade}年{classNum}組
-          </span>
-        )}
+        <button
+          onClick={handleLoad}
+          disabled={!canLoad || loadingStudents}
+          className="px-4 py-1.5 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed transition-opacity"
+        >
+          読み込む
+        </button>
       </div>
 
       {/* 生徒一覧 */}
@@ -159,7 +157,9 @@ export default function StudentMemoViewer({ lessonId }: Props) {
       )}
 
       {students === null && !loadingStudents && (
-        <p className="text-sm text-muted-foreground">学年とクラスを選択してください。</p>
+        <p className="text-sm text-muted-foreground">
+          学年またはクラスを指定して「読み込む」を押してください。
+        </p>
       )}
     </div>
   );

--- a/src/lib/db/memos.ts
+++ b/src/lib/db/memos.ts
@@ -100,25 +100,45 @@ export type StudentWithMemoCount = {
 /**
  * 指定学年・クラスの生徒一覧とメモ件数を取得する（teacher/admin 向け）
  * student_number の桁構造: 1桁目=学年, 2桁目=クラス, 3〜4桁目=出席番号
+ * grade / classNum はどちらか一方のみ、または両方を指定できる
  */
 export async function getStudentsWithMemoCounts(
   lessonId: string,
-  grade: number,
-  classNum: number
+  grade: number | null,
+  classNum: number | null
 ): Promise<StudentWithMemoCount[]> {
   const supabase = await createClient();
-  const min = grade * 1000 + classNum * 100;
-  const max = min + 99;
 
-  const { data: profiles, error: profilesError } = await supabase
+  let query = supabase
     .from("profiles")
     .select("id, display_name, student_number")
     .eq("role", "student")
-    .gte("student_number", min)
-    .lte("student_number", max)
-    .order("student_number", { ascending: true, nullsFirst: false });
+    .not("student_number", "is", null);
 
-  if (profilesError || !profiles) return [];
+  if (grade !== null && classNum !== null) {
+    const min = grade * 1000 + classNum * 100;
+    query = query.gte("student_number", min).lte("student_number", min + 99);
+  } else if (grade !== null) {
+    query = query.gte("student_number", grade * 1000).lte("student_number", grade * 1000 + 999);
+  }
+  // classNum のみの場合は全件取得して JS でフィルタ
+
+  const { data: rawProfiles, error: profilesError } = await query.order("student_number", {
+    ascending: true,
+    nullsFirst: false,
+  });
+
+  if (profilesError || !rawProfiles) return [];
+
+  const profiles =
+    grade === null && classNum !== null
+      ? rawProfiles.filter(
+          (p) =>
+            p.student_number !== null &&
+            Math.floor((p.student_number % 1000) / 100) === classNum
+        )
+      : rawProfiles;
+
   if (profiles.length === 0) return [];
 
   const { data: memos } = await supabase


### PR DESCRIPTION
## 概要
Phase 13（生徒メモ閲覧）のセルフレビューで発覚した問題を修正。バラバラのクラスの生徒が受ける授業に対応するため、学年のみ・クラスのみでも絞り込めるよう変更した。

## 変更内容
- `src/lib/db/memos.ts`: `getStudentsWithMemoCounts` の `grade` / `classNum` を `number | null` に変更し、学年のみ・クラスのみ・両方の3パターンに対応
- `src/app/api/teacher/lessons/[lessonId]/memo-students/route.ts`: クエリパラメータを任意化。両方未指定の場合のみ 400 を返すよう変更
- `src/components/teacher/student-memo-viewer.tsx`: 自動ロードを廃止し「読み込む」ボタンを追加。ドロップダウンに「指定なし」を追加

## 確認事項
- [x] セルフレビュー済み