### PR TITLE
feat: 小テスト回答詳細の保存機能を追加（Phase 15.5）

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -645,8 +645,8 @@ create table public.quiz_attempt_answers (
 
 ### タスク
 
-- [ ] マイグレーション：`quiz_attempt_answers` テーブルを追加（RLS含む）
-- [ ] `POST /api/quizzes/[quizId]/attempts` のレスポンスを拡張し、各問の回答詳細も保存
+- [x] マイグレーション：`quiz_attempt_answers` テーブルを追加（RLS含む）
+- [x] `POST /api/quizzes/[quizId]/attempts` のレスポンスを拡張し、各問の回答詳細も保存
 - [ ] 生徒が自分の回答履歴・正誤を確認できるUIを追加（任意）
 - [ ] 教師向け分析ページへの組み込み（Phase 13 と連携）
 
@@ -742,7 +742,7 @@ create table public.quiz_attempt_answers (
 [✅] Phase 13.7: エディタ機能拡張（表・画像）
 [--] Phase 14:  いいね機能（見送り）
 [✅] Phase 15:   小テスト完了ゲート
-[ ] Phase 15.5: 小テスト回答詳細の保存
+[🔄] Phase 15.5: 小テスト回答詳細の保存
 [ ] Phase 16:   トロフィー・実績機能
 [ ] Phase 17:   匿名プライベートコメント機能
 ```

--- a/src/app/api/quizzes/[quizId]/attempts/route.ts
+++ b/src/app/api/quizzes/[quizId]/attempts/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { createQuizAttempt, hasCompletedQuiz } from "@/lib/db/quizzes";
-import type { QuizQuestion } from "@/lib/db/quizzes";
+import type { QuizQuestion, QuizAttemptAnswerInput } from "@/lib/db/quizzes";
 
 type AnswerPayload =
   | { questionId: string; type: "multiple_choice"; selectedText: string }
@@ -44,24 +44,53 @@ export async function POST(req: NextRequest, { params }: Params) {
 
   let score = 0;
   let maxScore = 0;
+  const answerDetails: QuizAttemptAnswerInput[] = [];
 
   for (const q of questions as QuizQuestion[]) {
-    if (q.type === "short_answer") continue;
+    const answer = body.answers.find((a) => a.questionId === q.id);
+
+    if (q.type === "short_answer") {
+      answerDetails.push({
+        questionId: q.id,
+        answer: { type: "short_answer", text: answer?.type === "short_answer" ? answer.text : "" },
+        isCorrect: null,
+      });
+      continue;
+    }
+
     maxScore++;
 
-    const answer = body.answers.find((a) => a.questionId === q.id);
-    if (!answer) continue;
+    if (!answer) {
+      answerDetails.push({ questionId: q.id, answer: { type: q.type }, isCorrect: false });
+      continue;
+    }
 
+    let isCorrect = false;
     if (q.type === "multiple_choice" && answer.type === "multiple_choice") {
       const correctIndex = (q.correct_answer as { index: number }).index;
       const correctText = (q.options as string[])[correctIndex];
-      if (answer.selectedText === correctText) score++;
+      isCorrect = answer.selectedText === correctText;
+      if (isCorrect) score++;
+      answerDetails.push({
+        questionId: q.id,
+        answer: { type: "multiple_choice", selectedText: answer.selectedText },
+        isCorrect,
+      });
     } else if (q.type === "ordering" && answer.type === "ordering") {
-      if (JSON.stringify(answer.items) === JSON.stringify(q.correct_answer as string[])) score++;
+      isCorrect = JSON.stringify(answer.items) === JSON.stringify(q.correct_answer as string[]);
+      if (isCorrect) score++;
+      answerDetails.push({
+        questionId: q.id,
+        answer: { type: "ordering", items: answer.items },
+        isCorrect,
+      });
     }
   }
 
-  const ok = await createQuizAttempt({ quizId, userId: user.id, score, maxScore });
+  const ok = await createQuizAttempt(
+    { quizId, userId: user.id, score, maxScore },
+    answerDetails
+  );
   if (!ok) {
     return NextResponse.json({ data: null, error: "Failed to save attempt" }, { status: 500 });
   }

--- a/src/lib/db/quizzes.ts
+++ b/src/lib/db/quizzes.ts
@@ -28,6 +28,12 @@ export type QuizAttemptInput = {
   maxScore: number;
 };
 
+export type QuizAttemptAnswerInput = {
+  questionId: string;
+  answer: Record<string, unknown>;
+  isCorrect: boolean | null;
+};
+
 /**
  * レッスンに紐づくクイズと問題一覧を取得する
  */
@@ -151,17 +157,43 @@ export async function deleteQuiz(quizId: string): Promise<boolean> {
 }
 
 /**
- * 小テスト提出記録を保存する
+ * 小テスト提出記録と各問の回答詳細を保存する
  */
-export async function createQuizAttempt(input: QuizAttemptInput): Promise<boolean> {
+export async function createQuizAttempt(
+  input: QuizAttemptInput,
+  answers?: QuizAttemptAnswerInput[]
+): Promise<boolean> {
   const supabase = await createClient();
-  const { error } = await supabase.from("quiz_attempts").insert({
-    quiz_id: input.quizId,
-    user_id: input.userId,
-    score: input.score,
-    max_score: input.maxScore,
-  });
-  return !error;
+
+  const { data: attempt, error: attemptError } = await supabase
+    .from("quiz_attempts")
+    .insert({
+      quiz_id: input.quizId,
+      user_id: input.userId,
+      score: input.score,
+      max_score: input.maxScore,
+    })
+    .select("id")
+    .single();
+
+  if (attemptError || !attempt) return false;
+
+  if (answers && answers.length > 0) {
+    const rows = answers.map((a) => ({
+      attempt_id: attempt.id,
+      question_id: a.questionId,
+      answer: a.answer as Database["public"]["Tables"]["quiz_attempt_answers"]["Insert"]["answer"],
+      is_correct: a.isCorrect,
+    }));
+
+    const { error: answersError } = await supabase
+      .from("quiz_attempt_answers")
+      .insert(rows);
+
+    if (answersError) return false;
+  }
+
+  return true;
 }
 
 /**

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -186,6 +186,87 @@ export type Database = {
         }
         Relationships: []
       }
+      quiz_attempt_answers: {
+        Row: {
+          answer: Json
+          attempt_id: string
+          id: string
+          is_correct: boolean | null
+          question_id: string
+        }
+        Insert: {
+          answer: Json
+          attempt_id: string
+          id?: string
+          is_correct?: boolean | null
+          question_id: string
+        }
+        Update: {
+          answer?: Json
+          attempt_id?: string
+          id?: string
+          is_correct?: boolean | null
+          question_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "quiz_attempt_answers_attempt_id_fkey"
+            columns: ["attempt_id"]
+            isOneToOne: false
+            referencedRelation: "quiz_attempts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "quiz_attempt_answers_question_id_fkey"
+            columns: ["question_id"]
+            isOneToOne: false
+            referencedRelation: "quiz_questions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      quiz_attempts: {
+        Row: {
+          id: string
+          max_score: number
+          quiz_id: string
+          score: number
+          submitted_at: string
+          user_id: string
+        }
+        Insert: {
+          id?: string
+          max_score: number
+          quiz_id: string
+          score: number
+          submitted_at?: string
+          user_id: string
+        }
+        Update: {
+          id?: string
+          max_score?: number
+          quiz_id?: string
+          score?: number
+          submitted_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "quiz_attempts_quiz_id_fkey"
+            columns: ["quiz_id"]
+            isOneToOne: false
+            referencedRelation: "quizzes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "quiz_attempts_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       questions: {
         Row: {
           content: string

--- a/supabase/migrations/20260517000001_quiz_attempt_answers.sql
+++ b/supabase/migrations/20260517000001_quiz_attempt_answers.sql
@@ -1,0 +1,44 @@
+-- =====================
+-- quiz_attempt_answers（小テスト回答詳細）
+-- =====================
+
+create table public.quiz_attempt_answers (
+  id          uuid primary key default gen_random_uuid(),
+  attempt_id  uuid not null references public.quiz_attempts(id) on delete cascade,
+  question_id uuid not null references public.quiz_questions(id) on delete cascade,
+  answer      jsonb not null,
+  is_correct  boolean
+);
+
+alter table public.quiz_attempt_answers enable row level security;
+
+-- 自分の回答のみ読み取り可（attempt_id 経由で user_id を確認）
+create policy "quiz_attempt_answers_select_own" on public.quiz_attempt_answers
+  for select using (
+    exists (
+      select 1 from public.quiz_attempts
+      where id = attempt_id and user_id = auth.uid()
+    )
+  );
+
+-- 自分の受験記録への書き込みのみ可
+create policy "quiz_attempt_answers_insert_own" on public.quiz_attempt_answers
+  for insert with check (
+    exists (
+      select 1 from public.quiz_attempts
+      where id = attempt_id and user_id = auth.uid()
+    )
+  );
+
+-- teacher/admin は全件読み取り可
+create policy "quiz_attempt_answers_select_teacher" on public.quiz_attempt_answers
+  for select using (
+    exists (
+      select 1 from public.profiles
+      where id = auth.uid() and role in ('teacher', 'admin')
+    )
+  );
+
+-- 検索パフォーマンス向上のためインデックスを追加
+create index on public.quiz_attempt_answers (attempt_id);
+create index on public.quiz_attempt_answers (question_id);


### PR DESCRIPTION
## 概要

小テスト提出時に、スコア合計だけでなく各問の回答内容・正誤をDBに保存するよう拡張する。将来の結果一覧ページ（生徒向け）や教師分析との連携基盤となる。

## 変更内容

- `supabase/migrations/20260517000001_quiz_attempt_answers.sql`：`quiz_attempt_answers` テーブルを追加（RLS・インデックス含む）
- `src/lib/supabase/types.ts`：`quiz_attempts`（型定義が欠落していた）と `quiz_attempt_answers` の型定義を追加
- `src/lib/db/quizzes.ts`：`QuizAttemptAnswerInput` 型を追加、`createQuizAttempt` を拡張して回答詳細もバッチ INSERT
- `src/app/api/quizzes/[quizId]/attempts/route.ts`：採点ループで各問の回答詳細（選択内容・正誤）を収集し保存

## 確認事項

- [x] セルフレビュー済み