### PR TITLE
feat: 小テスト結果一覧ページを追加（Phase 15.8）

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -671,13 +671,17 @@ create table public.quiz_attempt_answers (
 
 ### タスク
 
-- [ ] `lib/db/quizzes.ts` に以下を追加
+- [x] `lib/db/quizzes.ts` に以下を追加
   - `getQuizResultsByUser()` — 自分の全受験履歴を科目・単元・レッスン階層で取得
-- [ ] `/quiz-results` ページを追加（Server Component）
+- [x] `/quiz-results` ページを追加（Server Component）
   - 科目 → 単元 → レッスンの階層で受験履歴を一覧表示
-  - 各受験について：受験日時・スコア・各問の正誤を表示
+  - レッスンごとに最高・平均の正答率（直近3回）を表示
+  - 単元ごとに各レッスン最高正答率の平均を表示
+  - 各受験について：受験日時・スコア・正答率・各問の正誤（○✕－）を表示
+  - `quiz_attempt_answers` がない旧データは「詳細な回答記録なし」と表示
   - 未受験のレッスンは表示しない（受験済みのみ）
-- [ ] NavBar の UserMenu に「小テスト結果」リンクを追加（全ロール表示）
+- [x] NavBar の UserMenu に「小テスト結果」リンクを追加（全ロール表示）
+- [x] `quiz-section.tsx` のスコア表示に正答率（%）を追加（例：5/8点（63%））
 
 ### マージ判断
 
@@ -772,9 +776,9 @@ create table public.quiz_attempt_answers (
 [--] Phase 14:   いいね機能（見送り）
 [✅] Phase 15:   小テスト完了ゲート
 [✅] Phase 15.5: 小テスト回答詳細の保存
-[ ] Phase 15.8: 小テスト結果一覧（生徒向け）
+[✅] Phase 15.8: 小テスト結果一覧（生徒向け）
 [ ] Phase 16:   トロフィー・実績機能
 [ ] Phase 17:   匿名プライベートコメント機能
 ```
 
-次の着手は **Phase 15.8: 小テスト結果一覧（生徒向け）**。
+次の着手は **Phase 16: トロフィー・実績機能**。

--- a/src/app/(student)/quiz-results/page.tsx
+++ b/src/app/(student)/quiz-results/page.tsx
@@ -1,8 +1,11 @@
 import Link from "next/link";
 import { getQuizResultsByUser } from "@/lib/db/quizzes";
 import type { QuizAttemptResult } from "@/lib/db/quizzes";
+import LessonAttemptHistory from "@/components/student/lesson-attempt-history";
 
 // ─── 型定義 ────────────────────────────────────────────────────────
+
+type FrequentlyMissed = { label: string };
 
 type LessonResult = {
   lessonId: string;
@@ -12,6 +15,7 @@ type LessonResult = {
   attempts: QuizAttemptResult[];
   recentMaxRate: number;
   recentAvgRate: number;
+  frequentlyMissed: FrequentlyMissed[];
 };
 
 type UnitResult = {
@@ -47,21 +51,33 @@ function computeLessonStats(attempts: QuizAttemptResult[]): {
   return { recentMaxRate, recentAvgRate };
 }
 
+function computeFrequentlyMissed(attempts: QuizAttemptResult[]): FrequentlyMissed[] {
+  const questionMap = new Map<string, { order: number; total: number; wrong: number }>();
+  for (const attempt of attempts) {
+    for (const ans of attempt.quiz_attempt_answers) {
+      if (ans.is_correct === null) continue;
+      const key = ans.quiz_questions.id;
+      const entry = questionMap.get(key) ?? { order: ans.quiz_questions.order, total: 0, wrong: 0 };
+      entry.total++;
+      if (!ans.is_correct) entry.wrong++;
+      questionMap.set(key, entry);
+    }
+  }
+  return [...questionMap.values()]
+    .filter((s) => s.total >= 2 && s.wrong > s.total / 2)
+    .sort((a, b) => a.order - b.order)
+    .map((s) => ({ label: `Q${s.order + 1}` }));
+}
+
 function rateColor(rate: number): string {
   if (rate >= 80) return "text-green-600";
   if (rate >= 60) return "text-amber-600";
   return "text-red-500";
 }
 
-function formatDate(dateStr: string): string {
-  const d = new Date(dateStr);
-  return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, "0")}/${String(d.getDate()).padStart(2, "0")} ${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
-}
-
 // ─── ツリー構築 ─────────────────────────────────────────────────────
 
 function buildTree(attempts: QuizAttemptResult[]): SubjectResult[] {
-  // lessonId → attempts[]
   const lessonMap = new Map<string, QuizAttemptResult[]>();
   for (const a of attempts) {
     const id = a.quizzes.lessons.id;
@@ -70,7 +86,6 @@ function buildTree(attempts: QuizAttemptResult[]): SubjectResult[] {
     lessonMap.set(id, list);
   }
 
-  // lessonId → lesson info（重複除去）
   const lessonInfoMap = new Map<
     string,
     { lessonId: string; lessonTitle: string; quizId: string; quizTitle: string; unitId: string; unitName: string; subjectId: string; subjectName: string; subjectOrder: number }
@@ -92,12 +107,12 @@ function buildTree(attempts: QuizAttemptResult[]): SubjectResult[] {
     }
   }
 
-  // subject → unit → lesson のツリーを構築
   const subjectMap = new Map<string, SubjectResult>();
 
   for (const info of lessonInfoMap.values()) {
     const lessonAttempts = lessonMap.get(info.lessonId) ?? [];
     const { recentMaxRate, recentAvgRate } = computeLessonStats(lessonAttempts);
+    const frequentlyMissed = computeFrequentlyMissed(lessonAttempts);
 
     const lesson: LessonResult = {
       lessonId: info.lessonId,
@@ -107,6 +122,7 @@ function buildTree(attempts: QuizAttemptResult[]): SubjectResult[] {
       attempts: lessonAttempts,
       recentMaxRate,
       recentAvgRate,
+      frequentlyMissed,
     };
 
     if (!subjectMap.has(info.subjectId)) {
@@ -127,7 +143,6 @@ function buildTree(attempts: QuizAttemptResult[]): SubjectResult[] {
     unit.lessons.push(lesson);
   }
 
-  // 単元平均 = 各レッスンの最高正答率の平均
   for (const subject of subjectMap.values()) {
     for (const unit of subject.units) {
       const maxRates = unit.lessons.map((l) => l.recentMaxRate);
@@ -167,7 +182,6 @@ export default async function QuizResultsPage() {
               <div className="space-y-8">
                 {subject.units.map((unit) => (
                   <section key={unit.unitId}>
-                    {/* 単元ヘッダー */}
                     <div className="flex items-center gap-3 mb-4">
                       <h3 className="text-base font-semibold text-muted-foreground">{unit.unitName}</h3>
                       <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
@@ -180,7 +194,7 @@ export default async function QuizResultsPage() {
 
                     <div className="space-y-5 pl-4 border-l-2 border-indigo-100">
                       {unit.lessons.map((lesson) => (
-                        <div key={lesson.lessonId} className="bg-card border rounded-lg p-5 space-y-4">
+                        <div key={lesson.lessonId} className="bg-card border rounded-lg p-5 space-y-3">
                           {/* レッスンヘッダー */}
                           <div className="flex items-start justify-between gap-2">
                             <div>
@@ -208,73 +222,13 @@ export default async function QuizResultsPage() {
                               </div>
                             </div>
                           </div>
-                          <p className="text-xs text-muted-foreground -mt-2">※ 統計は直近3回の受験が対象</p>
+                          <p className="text-xs text-muted-foreground">※ 統計は直近3回の受験が対象</p>
 
-                          {/* 受験履歴一覧 */}
-                          <div className="space-y-2">
-                            {lesson.attempts.map((attempt) => {
-                              const rate = toRate(attempt.score, attempt.max_score);
-                              const hasDetails = attempt.quiz_attempt_answers.length > 0;
-                              const sortedAnswers = hasDetails
-                                ? [...attempt.quiz_attempt_answers].sort(
-                                    (a, b) => a.quiz_questions.order - b.quiz_questions.order
-                                  )
-                                : [];
-
-                              return (
-                                <div
-                                  key={attempt.id}
-                                  className="rounded-md border bg-muted/30 px-4 py-3 space-y-2"
-                                >
-                                  {/* 日時 + スコア */}
-                                  <div className="flex items-center gap-3 flex-wrap">
-                                    <span className="text-xs text-muted-foreground font-mono">
-                                      {formatDate(attempt.submitted_at)}
-                                    </span>
-                                    {attempt.max_score > 0 ? (
-                                      <span className="text-sm font-medium">
-                                        {attempt.score} / {attempt.max_score} 点
-                                        <span className={`ml-1.5 font-bold ${rateColor(rate)}`}>
-                                          （{rate}%）
-                                        </span>
-                                      </span>
-                                    ) : (
-                                      <span className="text-sm text-muted-foreground">記述式のみ</span>
-                                    )}
-                                  </div>
-
-                                  {/* 問題ごとの正誤 */}
-                                  {hasDetails ? (
-                                    <div className="flex flex-wrap gap-1.5">
-                                      {sortedAnswers.map((ans, i) => (
-                                        <span
-                                          key={ans.id}
-                                          className={`inline-flex items-center gap-0.5 text-xs px-1.5 py-0.5 rounded ${
-                                            ans.is_correct === true
-                                              ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
-                                              : ans.is_correct === false
-                                              ? "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
-                                              : "bg-muted text-muted-foreground"
-                                          }`}
-                                        >
-                                          <span className="font-mono">Q{i + 1}</span>
-                                          <span>
-                                            {ans.is_correct === true
-                                              ? "○"
-                                              : ans.is_correct === false
-                                              ? "✕"
-                                              : "－"}
-                                          </span>
-                                        </span>
-                                      ))}
-                                    </div>
-                                  ) : (
-                                    <p className="text-xs text-muted-foreground">詳細な回答記録なし</p>
-                                  )}
-                                </div>
-                              );
-                            })}
-                          </div>
+                          {/* 受験履歴（クライアントコンポーネント） */}
+                          <LessonAttemptHistory
+                            attempts={lesson.attempts}
+                            frequentlyMissed={lesson.frequentlyMissed}
+                          />
                         </div>
                       ))}
                     </div>

--- a/src/app/(student)/quiz-results/page.tsx
+++ b/src/app/(student)/quiz-results/page.tsx
@@ -1,0 +1,290 @@
+import Link from "next/link";
+import { getQuizResultsByUser } from "@/lib/db/quizzes";
+import type { QuizAttemptResult } from "@/lib/db/quizzes";
+
+// ─── 型定義 ────────────────────────────────────────────────────────
+
+type LessonResult = {
+  lessonId: string;
+  lessonTitle: string;
+  quizId: string;
+  quizTitle: string;
+  attempts: QuizAttemptResult[];
+  recentMaxRate: number;
+  recentAvgRate: number;
+};
+
+type UnitResult = {
+  unitId: string;
+  unitName: string;
+  unitAvgRate: number;
+  lessons: LessonResult[];
+};
+
+type SubjectResult = {
+  subjectId: string;
+  subjectName: string;
+  subjectOrder: number;
+  units: UnitResult[];
+};
+
+// ─── ユーティリティ ─────────────────────────────────────────────────
+
+function toRate(score: number, maxScore: number): number {
+  if (maxScore === 0) return 0;
+  return Math.round((score / maxScore) * 100);
+}
+
+function computeLessonStats(attempts: QuizAttemptResult[]): {
+  recentMaxRate: number;
+  recentAvgRate: number;
+} {
+  const recent = attempts.slice(0, 3);
+  if (recent.length === 0) return { recentMaxRate: 0, recentAvgRate: 0 };
+  const rates = recent.map((a) => toRate(a.score, a.max_score));
+  const recentMaxRate = Math.max(...rates);
+  const recentAvgRate = Math.round(rates.reduce((s, r) => s + r, 0) / rates.length);
+  return { recentMaxRate, recentAvgRate };
+}
+
+function rateColor(rate: number): string {
+  if (rate >= 80) return "text-green-600";
+  if (rate >= 60) return "text-amber-600";
+  return "text-red-500";
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, "0")}/${String(d.getDate()).padStart(2, "0")} ${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+// ─── ツリー構築 ─────────────────────────────────────────────────────
+
+function buildTree(attempts: QuizAttemptResult[]): SubjectResult[] {
+  // lessonId → attempts[]
+  const lessonMap = new Map<string, QuizAttemptResult[]>();
+  for (const a of attempts) {
+    const id = a.quizzes.lessons.id;
+    const list = lessonMap.get(id) ?? [];
+    list.push(a);
+    lessonMap.set(id, list);
+  }
+
+  // lessonId → lesson info（重複除去）
+  const lessonInfoMap = new Map<
+    string,
+    { lessonId: string; lessonTitle: string; quizId: string; quizTitle: string; unitId: string; unitName: string; subjectId: string; subjectName: string; subjectOrder: number }
+  >();
+  for (const a of attempts) {
+    const l = a.quizzes.lessons;
+    if (!lessonInfoMap.has(l.id)) {
+      lessonInfoMap.set(l.id, {
+        lessonId: l.id,
+        lessonTitle: l.title,
+        quizId: a.quizzes.id,
+        quizTitle: a.quizzes.title,
+        unitId: l.units.id,
+        unitName: l.units.name,
+        subjectId: l.units.subjects.id,
+        subjectName: l.units.subjects.name,
+        subjectOrder: l.units.subjects.order,
+      });
+    }
+  }
+
+  // subject → unit → lesson のツリーを構築
+  const subjectMap = new Map<string, SubjectResult>();
+
+  for (const info of lessonInfoMap.values()) {
+    const lessonAttempts = lessonMap.get(info.lessonId) ?? [];
+    const { recentMaxRate, recentAvgRate } = computeLessonStats(lessonAttempts);
+
+    const lesson: LessonResult = {
+      lessonId: info.lessonId,
+      lessonTitle: info.lessonTitle,
+      quizId: info.quizId,
+      quizTitle: info.quizTitle,
+      attempts: lessonAttempts,
+      recentMaxRate,
+      recentAvgRate,
+    };
+
+    if (!subjectMap.has(info.subjectId)) {
+      subjectMap.set(info.subjectId, {
+        subjectId: info.subjectId,
+        subjectName: info.subjectName,
+        subjectOrder: info.subjectOrder,
+        units: [],
+      });
+    }
+    const subject = subjectMap.get(info.subjectId)!;
+
+    let unit = subject.units.find((u) => u.unitId === info.unitId);
+    if (!unit) {
+      unit = { unitId: info.unitId, unitName: info.unitName, unitAvgRate: 0, lessons: [] };
+      subject.units.push(unit);
+    }
+    unit.lessons.push(lesson);
+  }
+
+  // 単元平均 = 各レッスンの最高正答率の平均
+  for (const subject of subjectMap.values()) {
+    for (const unit of subject.units) {
+      const maxRates = unit.lessons.map((l) => l.recentMaxRate);
+      unit.unitAvgRate = Math.round(maxRates.reduce((s, r) => s + r, 0) / maxRates.length);
+    }
+  }
+
+  return [...subjectMap.values()].sort((a, b) => a.subjectOrder - b.subjectOrder);
+}
+
+// ─── コンポーネント ──────────────────────────────────────────────────
+
+export default async function QuizResultsPage() {
+  const attempts = await getQuizResultsByUser();
+  const tree = buildTree(attempts);
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-6">小テスト結果一覧</h1>
+
+      {tree.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-20 text-center">
+          <div className="w-16 h-16 rounded-full bg-indigo-50 flex items-center justify-center mb-4">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="w-8 h-8 text-indigo-400">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V19.5a2.25 2.25 0 002.25 2.25h.75" />
+            </svg>
+          </div>
+          <p className="text-muted-foreground text-sm">
+            まだ小テストを受験していません。授業ページで小テストに挑戦してみましょう。
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-12">
+          {tree.map((subject) => (
+            <section key={subject.subjectId}>
+              <h2 className="text-xl font-bold border-b pb-3 mb-6">{subject.subjectName}</h2>
+              <div className="space-y-8">
+                {subject.units.map((unit) => (
+                  <section key={unit.unitId}>
+                    {/* 単元ヘッダー */}
+                    <div className="flex items-center gap-3 mb-4">
+                      <h3 className="text-base font-semibold text-muted-foreground">{unit.unitName}</h3>
+                      <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+                        単元平均{" "}
+                        <span className={`font-bold ${rateColor(unit.unitAvgRate)}`}>
+                          {unit.unitAvgRate}%
+                        </span>
+                      </span>
+                    </div>
+
+                    <div className="space-y-5 pl-4 border-l-2 border-indigo-100">
+                      {unit.lessons.map((lesson) => (
+                        <div key={lesson.lessonId} className="bg-card border rounded-lg p-5 space-y-4">
+                          {/* レッスンヘッダー */}
+                          <div className="flex items-start justify-between gap-2">
+                            <div>
+                              <Link
+                                href={`/lessons/${lesson.lessonId}`}
+                                className="font-medium hover:text-indigo-600 transition-colors"
+                              >
+                                {lesson.lessonTitle}
+                              </Link>
+                              <p className="text-xs text-muted-foreground mt-0.5">{lesson.quizTitle}</p>
+                            </div>
+                            {/* 統計（直近3回） */}
+                            <div className="shrink-0 flex gap-4 text-sm">
+                              <div className="text-center">
+                                <p className="text-xs text-muted-foreground">最高</p>
+                                <p className={`font-bold text-base ${rateColor(lesson.recentMaxRate)}`}>
+                                  {lesson.recentMaxRate}%
+                                </p>
+                              </div>
+                              <div className="text-center">
+                                <p className="text-xs text-muted-foreground">平均</p>
+                                <p className={`font-bold text-base ${rateColor(lesson.recentAvgRate)}`}>
+                                  {lesson.recentAvgRate}%
+                                </p>
+                              </div>
+                            </div>
+                          </div>
+                          <p className="text-xs text-muted-foreground -mt-2">※ 統計は直近3回の受験が対象</p>
+
+                          {/* 受験履歴一覧 */}
+                          <div className="space-y-2">
+                            {lesson.attempts.map((attempt) => {
+                              const rate = toRate(attempt.score, attempt.max_score);
+                              const hasDetails = attempt.quiz_attempt_answers.length > 0;
+                              const sortedAnswers = hasDetails
+                                ? [...attempt.quiz_attempt_answers].sort(
+                                    (a, b) => a.quiz_questions.order - b.quiz_questions.order
+                                  )
+                                : [];
+
+                              return (
+                                <div
+                                  key={attempt.id}
+                                  className="rounded-md border bg-muted/30 px-4 py-3 space-y-2"
+                                >
+                                  {/* 日時 + スコア */}
+                                  <div className="flex items-center gap-3 flex-wrap">
+                                    <span className="text-xs text-muted-foreground font-mono">
+                                      {formatDate(attempt.submitted_at)}
+                                    </span>
+                                    {attempt.max_score > 0 ? (
+                                      <span className="text-sm font-medium">
+                                        {attempt.score} / {attempt.max_score} 点
+                                        <span className={`ml-1.5 font-bold ${rateColor(rate)}`}>
+                                          （{rate}%）
+                                        </span>
+                                      </span>
+                                    ) : (
+                                      <span className="text-sm text-muted-foreground">記述式のみ</span>
+                                    )}
+                                  </div>
+
+                                  {/* 問題ごとの正誤 */}
+                                  {hasDetails ? (
+                                    <div className="flex flex-wrap gap-1.5">
+                                      {sortedAnswers.map((ans, i) => (
+                                        <span
+                                          key={ans.id}
+                                          className={`inline-flex items-center gap-0.5 text-xs px-1.5 py-0.5 rounded ${
+                                            ans.is_correct === true
+                                              ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                                              : ans.is_correct === false
+                                              ? "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
+                                              : "bg-muted text-muted-foreground"
+                                          }`}
+                                        >
+                                          <span className="font-mono">Q{i + 1}</span>
+                                          <span>
+                                            {ans.is_correct === true
+                                              ? "○"
+                                              : ans.is_correct === false
+                                              ? "✕"
+                                              : "－"}
+                                          </span>
+                                        </span>
+                                      ))}
+                                    </div>
+                                  ) : (
+                                    <p className="text-xs text-muted-foreground">詳細な回答記録なし</p>
+                                  )}
+                                </div>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </section>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/quizzes/[quizId]/attempts/route.ts
+++ b/src/app/api/quizzes/[quizId]/attempts/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { createQuizAttempt, getRecentQuizAttempts } from "@/lib/db/quizzes";
+import { createQuizAttempt, getRecentQuizAttemptsWithAnswers } from "@/lib/db/quizzes";
 import type { QuizQuestion, QuizAttemptAnswerInput } from "@/lib/db/quizzes";
 
 type AnswerPayload =
@@ -16,7 +16,7 @@ export async function GET(_req: NextRequest, { params }: Params) {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
 
-  const attempts = await getRecentQuizAttempts(quizId, user.id);
+  const attempts = await getRecentQuizAttemptsWithAnswers(quizId, user.id);
   return NextResponse.json({ data: attempts, error: null });
 }
 

--- a/src/app/api/quizzes/[quizId]/attempts/route.ts
+++ b/src/app/api/quizzes/[quizId]/attempts/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { createQuizAttempt, hasCompletedQuiz } from "@/lib/db/quizzes";
+import { createQuizAttempt, getRecentQuizAttempts } from "@/lib/db/quizzes";
 import type { QuizQuestion, QuizAttemptAnswerInput } from "@/lib/db/quizzes";
 
 type AnswerPayload =
@@ -16,8 +16,8 @@ export async function GET(_req: NextRequest, { params }: Params) {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
 
-  const completed = await hasCompletedQuiz(quizId, user.id);
-  return NextResponse.json({ data: { completed }, error: null });
+  const attempts = await getRecentQuizAttempts(quizId, user.id);
+  return NextResponse.json({ data: attempts, error: null });
 }
 
 export async function POST(req: NextRequest, { params }: Params) {

--- a/src/components/lesson/quiz-section.tsx
+++ b/src/components/lesson/quiz-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import {
   DndContext,
   closestCenter,
@@ -284,7 +284,14 @@ function initAnswer(question: QuizQuestion): Answer {
   return { type: "ordering", items };
 }
 
-type RecentAttemptSummary = { score: number; max_score: number };
+type RecentAttemptDetail = {
+  score: number;
+  max_score: number;
+  quiz_attempt_answers: {
+    is_correct: boolean | null;
+    quiz_questions: { id: string; order: number };
+  }[];
+};
 
 type Props = {
   quiz: QuizWithQuestions;
@@ -296,17 +303,45 @@ export default function QuizSection({ quiz, onCompleted }: Props) {
     quiz.questions.map(initAnswer)
   );
   const [quizState, setQuizState] = useState<QuizState>("answering");
-  const [recentAttempts, setRecentAttempts] = useState<RecentAttemptSummary[]>([]);
+  const [recentAttempts, setRecentAttempts] = useState<RecentAttemptDetail[]>([]);
+
+  useEffect(() => {
+    fetch(`/api/quizzes/${quiz.id}/attempts`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json: { data: RecentAttemptDetail[] | null } | null) => {
+        if (json?.data) setRecentAttempts(json.data);
+      })
+      .catch(() => {});
+  }, [quiz.id]);
 
   const recentStats = useMemo(() => {
     const autoGraded = recentAttempts.filter((a) => a.max_score > 0);
-    if (autoGraded.length < 2) return null;
-    const rates = autoGraded.map((a) => Math.round((a.score / a.max_score) * 100));
+    if (autoGraded.length === 0) return null;
+    const recent3 = autoGraded.slice(0, 3);
+    const rates = recent3.map((a) => Math.round((a.score / a.max_score) * 100));
     return {
       max: Math.max(...rates),
       avg: Math.round(rates.reduce((s, r) => s + r, 0) / rates.length),
-      count: autoGraded.length,
+      count: recent3.length,
     };
+  }, [recentAttempts]);
+
+  const frequentlyMissed = useMemo(() => {
+    const questionMap = new Map<string, { order: number; total: number; wrong: number }>();
+    for (const attempt of recentAttempts) {
+      for (const ans of attempt.quiz_attempt_answers) {
+        if (ans.is_correct === null) continue;
+        const key = ans.quiz_questions.id;
+        const entry = questionMap.get(key) ?? { order: ans.quiz_questions.order, total: 0, wrong: 0 };
+        entry.total++;
+        if (!ans.is_correct) entry.wrong++;
+        questionMap.set(key, entry);
+      }
+    }
+    return [...questionMap.values()]
+      .filter((s) => s.total >= 2 && s.wrong > s.total / 2)
+      .sort((a, b) => a.order - b.order)
+      .map((s) => `Q${s.order + 1}`);
   }, [recentAttempts]);
 
   const score = useMemo(() => {
@@ -359,7 +394,7 @@ export default function QuizSection({ quiz, onCompleted }: Props) {
       onCompleted?.();
       const statsRes = await fetch(`/api/quizzes/${quiz.id}/attempts`);
       if (statsRes.ok) {
-        const json = (await statsRes.json()) as { data: RecentAttemptSummary[] | null };
+        const json = (await statsRes.json()) as { data: RecentAttemptDetail[] | null };
         if (json.data) setRecentAttempts(json.data);
       }
     }
@@ -377,19 +412,12 @@ export default function QuizSection({ quiz, onCompleted }: Props) {
         <span className="text-sm text-muted-foreground">{quiz.questions.length} 問</span>
       </div>
 
-      {quizState === "submitted" && score !== null && (
-        <div className="rounded-lg border bg-card p-4 text-center space-y-2">
-          {score.autoGradable > 0 && (
-            <p className="text-2xl font-bold">
-              {score.correct} / {score.autoGradable}
-              <span className="text-base font-normal text-muted-foreground ml-1">点</span>
-              <span className="text-lg font-normal text-muted-foreground ml-2">
-                （{Math.round((score.correct / score.autoGradable) * 100)}%）
-              </span>
-            </p>
-          )}
+      {/* これまでの記録（受験前・受験後ともに表示、初回は非表示） */}
+      {(recentStats !== null || frequentlyMissed.length > 0) && (
+        <div className="rounded-lg border bg-muted/40 p-4 space-y-2.5">
+          <p className="text-xs font-medium text-muted-foreground">これまでの記録</p>
           {recentStats && (
-            <div className="flex items-center justify-center gap-6 pt-2 border-t text-sm">
+            <div className="flex items-center gap-6 text-sm">
               <div className="text-center">
                 <p className="text-xs text-muted-foreground">直近最高</p>
                 <p className="font-bold">{recentStats.max}%</p>
@@ -400,6 +428,34 @@ export default function QuizSection({ quiz, onCompleted }: Props) {
               </div>
               <p className="text-xs text-muted-foreground self-end pb-0.5">直近{recentStats.count}回</p>
             </div>
+          )}
+          {frequentlyMissed.length > 0 && (
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-xs text-muted-foreground shrink-0">間違いが多い問題:</span>
+              {frequentlyMissed.map((label) => (
+                <span
+                  key={label}
+                  className="inline-block px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 text-xs font-medium"
+                >
+                  {label}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* 提出後のスコアカード */}
+      {quizState === "submitted" && score !== null && (
+        <div className="rounded-lg border bg-card p-4 text-center space-y-1">
+          {score.autoGradable > 0 && (
+            <p className="text-2xl font-bold">
+              {score.correct} / {score.autoGradable}
+              <span className="text-base font-normal text-muted-foreground ml-1">点</span>
+              <span className="text-lg font-normal text-muted-foreground ml-2">
+                （{Math.round((score.correct / score.autoGradable) * 100)}%）
+              </span>
+            </p>
           )}
           {quiz.questions.some((q) => q.type === "short_answer") && (
             <p className="text-sm text-muted-foreground">記述式は模範解答を参考に自己採点してください</p>

--- a/src/components/lesson/quiz-section.tsx
+++ b/src/components/lesson/quiz-section.tsx
@@ -284,6 +284,8 @@ function initAnswer(question: QuizQuestion): Answer {
   return { type: "ordering", items };
 }
 
+type RecentAttemptSummary = { score: number; max_score: number };
+
 type Props = {
   quiz: QuizWithQuestions;
   onCompleted?: () => void;
@@ -294,6 +296,18 @@ export default function QuizSection({ quiz, onCompleted }: Props) {
     quiz.questions.map(initAnswer)
   );
   const [quizState, setQuizState] = useState<QuizState>("answering");
+  const [recentAttempts, setRecentAttempts] = useState<RecentAttemptSummary[]>([]);
+
+  const recentStats = useMemo(() => {
+    const autoGraded = recentAttempts.filter((a) => a.max_score > 0);
+    if (autoGraded.length < 2) return null;
+    const rates = autoGraded.map((a) => Math.round((a.score / a.max_score) * 100));
+    return {
+      max: Math.max(...rates),
+      avg: Math.round(rates.reduce((s, r) => s + r, 0) / rates.length),
+      count: autoGraded.length,
+    };
+  }, [recentAttempts]);
 
   const score = useMemo(() => {
     if (quizState !== "submitted") return null;
@@ -343,6 +357,11 @@ export default function QuizSection({ quiz, onCompleted }: Props) {
 
     if (res.ok) {
       onCompleted?.();
+      const statsRes = await fetch(`/api/quizzes/${quiz.id}/attempts`);
+      if (statsRes.ok) {
+        const json = (await statsRes.json()) as { data: RecentAttemptSummary[] | null };
+        if (json.data) setRecentAttempts(json.data);
+      }
     }
   };
 
@@ -359,7 +378,7 @@ export default function QuizSection({ quiz, onCompleted }: Props) {
       </div>
 
       {quizState === "submitted" && score !== null && (
-        <div className="rounded-lg border bg-card p-4 text-center space-y-1">
+        <div className="rounded-lg border bg-card p-4 text-center space-y-2">
           {score.autoGradable > 0 && (
             <p className="text-2xl font-bold">
               {score.correct} / {score.autoGradable}
@@ -368,6 +387,19 @@ export default function QuizSection({ quiz, onCompleted }: Props) {
                 （{Math.round((score.correct / score.autoGradable) * 100)}%）
               </span>
             </p>
+          )}
+          {recentStats && (
+            <div className="flex items-center justify-center gap-6 pt-2 border-t text-sm">
+              <div className="text-center">
+                <p className="text-xs text-muted-foreground">直近最高</p>
+                <p className="font-bold">{recentStats.max}%</p>
+              </div>
+              <div className="text-center">
+                <p className="text-xs text-muted-foreground">直近平均</p>
+                <p className="font-bold">{recentStats.avg}%</p>
+              </div>
+              <p className="text-xs text-muted-foreground self-end pb-0.5">直近{recentStats.count}回</p>
+            </div>
           )}
           {quiz.questions.some((q) => q.type === "short_answer") && (
             <p className="text-sm text-muted-foreground">記述式は模範解答を参考に自己採点してください</p>

--- a/src/components/lesson/quiz-section.tsx
+++ b/src/components/lesson/quiz-section.tsx
@@ -364,6 +364,9 @@ export default function QuizSection({ quiz, onCompleted }: Props) {
             <p className="text-2xl font-bold">
               {score.correct} / {score.autoGradable}
               <span className="text-base font-normal text-muted-foreground ml-1">点</span>
+              <span className="text-lg font-normal text-muted-foreground ml-2">
+                （{Math.round((score.correct / score.autoGradable) * 100)}%）
+              </span>
             </p>
           )}
           {quiz.questions.some((q) => q.type === "short_answer") && (

--- a/src/components/shared/user-menu.tsx
+++ b/src/components/shared/user-menu.tsx
@@ -59,6 +59,9 @@ export default function UserMenu({ displayName, role }: Props) {
         <DropdownMenuItem asChild>
           <Link href="/memos">📝 メモ一覧</Link>
         </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link href="/quiz-results">📊 小テスト結果</Link>
+        </DropdownMenuItem>
         {(role === "teacher" || role === "admin") && (
           <>
             <DropdownMenuSeparator />

--- a/src/components/student/lesson-attempt-history.tsx
+++ b/src/components/student/lesson-attempt-history.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState } from "react";
+import type { QuizAttemptResult } from "@/lib/db/quizzes";
+
+type FrequentlyMissed = { label: string };
+
+type Props = {
+  attempts: QuizAttemptResult[];
+  frequentlyMissed: FrequentlyMissed[];
+};
+
+function toRate(score: number, maxScore: number): number {
+  if (maxScore === 0) return 0;
+  return Math.round((score / maxScore) * 100);
+}
+
+function rateColor(rate: number): string {
+  if (rate >= 80) return "text-green-600";
+  if (rate >= 60) return "text-amber-600";
+  return "text-red-500";
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, "0")}/${String(d.getDate()).padStart(2, "0")} ${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+export default function LessonAttemptHistory({ attempts, frequentlyMissed }: Props) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="space-y-2">
+      {frequentlyMissed.length > 0 && (
+        <div className="flex items-center gap-2 flex-wrap text-sm">
+          <span className="text-xs text-muted-foreground shrink-0">間違いが多い問題:</span>
+          {frequentlyMissed.map((q) => (
+            <span
+              key={q.label}
+              className="inline-block px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 text-xs font-medium"
+            >
+              {q.label}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <button
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={`transition-transform ${open ? "rotate-90" : ""}`}
+        >
+          <path d="m9 18 6-6-6-6" />
+        </svg>
+        受験履歴 ({attempts.length}件)
+      </button>
+
+      {open && (
+        <div className="space-y-2 pt-1">
+          {attempts.map((attempt) => {
+            const rate = toRate(attempt.score, attempt.max_score);
+            const hasDetails = attempt.quiz_attempt_answers.length > 0;
+            const sortedAnswers = hasDetails
+              ? [...attempt.quiz_attempt_answers].sort(
+                  (a, b) => a.quiz_questions.order - b.quiz_questions.order
+                )
+              : [];
+
+            return (
+              <div
+                key={attempt.id}
+                className="rounded-md border bg-muted/30 px-4 py-3 space-y-2"
+              >
+                <div className="flex items-center gap-3 flex-wrap">
+                  <span className="text-xs text-muted-foreground font-mono">
+                    {formatDate(attempt.submitted_at)}
+                  </span>
+                  {attempt.max_score > 0 ? (
+                    <span className="text-sm font-medium">
+                      {attempt.score} / {attempt.max_score} 点
+                      <span className={`ml-1.5 font-bold ${rateColor(rate)}`}>
+                        （{rate}%）
+                      </span>
+                    </span>
+                  ) : (
+                    <span className="text-sm text-muted-foreground">記述式のみ</span>
+                  )}
+                </div>
+
+                {hasDetails ? (
+                  <div className="flex flex-wrap gap-1.5">
+                    {sortedAnswers.map((ans, i) => (
+                      <span
+                        key={ans.id}
+                        className={`inline-flex items-center gap-0.5 text-xs px-1.5 py-0.5 rounded ${
+                          ans.is_correct === true
+                            ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                            : ans.is_correct === false
+                            ? "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
+                            : "bg-muted text-muted-foreground"
+                        }`}
+                      >
+                        <span className="font-mono">Q{i + 1}</span>
+                        <span>
+                          {ans.is_correct === true ? "○" : ans.is_correct === false ? "✕" : "－"}
+                        </span>
+                      </span>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-xs text-muted-foreground">詳細な回答記録なし</p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/db/quizzes.ts
+++ b/src/lib/db/quizzes.ts
@@ -196,6 +196,92 @@ export async function createQuizAttempt(
   return true;
 }
 
+// ─── 小テスト結果一覧用の型 ───────────────────────────────────────
+
+export type AttemptAnswerResult = {
+  id: string;
+  is_correct: boolean | null;
+  quiz_questions: {
+    id: string;
+    type: Database["public"]["Enums"]["quiz_question_type"];
+    order: number;
+  };
+};
+
+export type QuizAttemptResult = {
+  id: string;
+  score: number;
+  max_score: number;
+  submitted_at: string;
+  quizzes: {
+    id: string;
+    title: string;
+    lessons: {
+      id: string;
+      title: string;
+      units: {
+        id: string;
+        name: string;
+        subjects: {
+          id: string;
+          name: string;
+          order: number;
+        };
+      };
+    };
+  };
+  quiz_attempt_answers: AttemptAnswerResult[];
+};
+
+/**
+ * ログインユーザーの全受験履歴を階層情報と回答詳細つきで取得する
+ */
+export async function getQuizResultsByUser(): Promise<QuizAttemptResult[]> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return [];
+
+  const { data, error } = await supabase
+    .from("quiz_attempts")
+    .select(`
+      id,
+      score,
+      max_score,
+      submitted_at,
+      quizzes (
+        id,
+        title,
+        lessons (
+          id,
+          title,
+          units (
+            id,
+            name,
+            subjects (
+              id,
+              name,
+              order
+            )
+          )
+        )
+      ),
+      quiz_attempt_answers (
+        id,
+        is_correct,
+        quiz_questions (
+          id,
+          type,
+          order
+        )
+      )
+    `)
+    .eq("user_id", user.id)
+    .order("submitted_at", { ascending: false });
+
+  if (error || !data) return [];
+  return data as unknown as QuizAttemptResult[];
+}
+
 /**
  * ユーザーが指定クイズを1回以上提出済みか確認する
  */

--- a/src/lib/db/quizzes.ts
+++ b/src/lib/db/quizzes.ts
@@ -282,6 +282,33 @@ export async function getQuizResultsByUser(): Promise<QuizAttemptResult[]> {
   return data as unknown as QuizAttemptResult[];
 }
 
+// ─── 直近の受験スコア取得 ──────────────────────────────────────────
+
+export type RecentAttemptSummary = {
+  score: number;
+  max_score: number;
+  submitted_at: string;
+};
+
+/**
+ * 指定ユーザーの指定クイズ直近3回の受験スコアを取得する
+ */
+export async function getRecentQuizAttempts(
+  quizId: string,
+  userId: string
+): Promise<RecentAttemptSummary[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("quiz_attempts")
+    .select("score, max_score, submitted_at")
+    .eq("quiz_id", quizId)
+    .eq("user_id", userId)
+    .order("submitted_at", { ascending: false })
+    .limit(3);
+  if (error || !data) return [];
+  return data;
+}
+
 /**
  * ユーザーが指定クイズを1回以上提出済みか確認する
  */

--- a/src/lib/db/quizzes.ts
+++ b/src/lib/db/quizzes.ts
@@ -282,31 +282,46 @@ export async function getQuizResultsByUser(): Promise<QuizAttemptResult[]> {
   return data as unknown as QuizAttemptResult[];
 }
 
-// ─── 直近の受験スコア取得 ──────────────────────────────────────────
+// ─── 直近の受験スコア取得（回答詳細付き） ────────────────────────────
 
-export type RecentAttemptSummary = {
+export type RecentAttemptDetail = {
   score: number;
   max_score: number;
   submitted_at: string;
+  quiz_attempt_answers: {
+    is_correct: boolean | null;
+    quiz_questions: { id: string; order: number };
+  }[];
 };
 
 /**
- * 指定ユーザーの指定クイズ直近3回の受験スコアを取得する
+ * 指定ユーザーの指定クイズ直近10回の受験を回答詳細付きで取得する
  */
-export async function getRecentQuizAttempts(
+export async function getRecentQuizAttemptsWithAnswers(
   quizId: string,
   userId: string
-): Promise<RecentAttemptSummary[]> {
+): Promise<RecentAttemptDetail[]> {
   const supabase = await createClient();
   const { data, error } = await supabase
     .from("quiz_attempts")
-    .select("score, max_score, submitted_at")
+    .select(`
+      score,
+      max_score,
+      submitted_at,
+      quiz_attempt_answers (
+        is_correct,
+        quiz_questions (
+          id,
+          order
+        )
+      )
+    `)
     .eq("quiz_id", quizId)
     .eq("user_id", userId)
     .order("submitted_at", { ascending: false })
-    .limit(3);
+    .limit(10);
   if (error || !data) return [];
-  return data;
+  return data as unknown as RecentAttemptDetail[];
 }
 
 /**


### PR DESCRIPTION
## 概要

生徒が自分の小テスト受験履歴を確認できる `/quiz-results` ページを新設。正答率の統計（直近3回の最高・平均）を科目・単元・レッスン階層で表示し、受験ごとの問題別正誤も確認できる。

## 変更内容

- `src/lib/db/quizzes.ts`：`getQuizResultsByUser()` を追加。受験履歴を階層情報・回答詳細つきで取得
- `src/app/(student)/quiz-results/page.tsx`：新規ページ（Server Component）
  - 科目→単元→レッスンの階層で受験履歴を一覧表示
  - レッスンごとに最高・平均正答率（直近3回）を表示
  - 単元ごとに各レッスン最高正答率の平均を表示
  - 受験ごとに日時・スコア・正答率・問題別正誤（○✕－）を表示
  - `quiz_attempt_answers` がない旧データは「詳細な回答記録なし」と表示（後方互換）
- `src/components/shared/user-menu.tsx`：「📊 小テスト結果」リンクを追加（全ロール表示）
- `src/components/lesson/quiz-section.tsx`：スコア表示を「5/8点（63%）」形式に変更
- `docs/roadmap.md`：Phase 15.8 を完了済みに更新

## 確認事項

- [x] セルフレビュー済み