### PR TITLE
feat: Vercel Analytics 導入

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -743,6 +743,29 @@ create table public.quiz_attempt_answers (
 
 ---
 
+## Phase 18: Vercel Analytics 導入
+
+> サイトのページビューとパフォーマンス指標を可視化する。
+
+### 設計方針
+
+- Vercel 公式の `@vercel/analytics` を使用してページビューを計測する
+- `@vercel/speed-insights` も合わせて導入し、Core Web Vitals（LCP・FID・CLS）を計測する
+- `app/layout.tsx` にコンポーネントを追加するだけで全ページに適用される（変更箇所は1ファイルのみ）
+- 無料枠（Hobby プラン：月10万イベントまで）内で運用可能
+
+### タスク
+
+- [ ] `@vercel/analytics` をインストール
+- [ ] `@vercel/speed-insights` をインストール
+- [ ] `app/layout.tsx` に `<Analytics />` と `<SpeedInsights />` を追加
+
+### マージ判断
+
+Vercel ダッシュボードの Analytics タブでデータが収集されていることを確認してからマージ
+
+---
+
 ## ウェイトリスト
 
 > 実装予定はあるが、時期未定のタスク。優先度が上がった時点でフェーズに組み込む。
@@ -779,6 +802,7 @@ create table public.quiz_attempt_answers (
 [✅] Phase 15.8: 小テスト結果一覧（生徒向け）
 [ ] Phase 16:   トロフィー・実績機能
 [ ] Phase 17:   匿名プライベートコメント機能
+[ ] Phase 18:   Vercel Analytics 導入
 ```
 
 次の着手は **Phase 16: トロフィー・実績機能**。

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,8 @@
         "@tiptap/extension-table-row": "^3.23.1",
         "@tiptap/react": "^3.20.1",
         "@tiptap/starter-kit": "^3.20.1",
+        "@vercel/analytics": "^2.0.1",
+        "@vercel/speed-insights": "^2.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lowlight": "^3.3.0",
@@ -4444,6 +4446,86 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "@tiptap/extension-table-row": "^3.23.1",
     "@tiptap/react": "^3.20.1",
     "@tiptap/starter-kit": "^3.20.1",
+    "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lowlight": "^3.3.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,8 @@ import NavBar from "@/components/shared/nav-bar";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import NextTopLoader from "nextjs-toploader";
+import { Analytics } from "@vercel/analytics/next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -37,6 +39,8 @@ export default function RootLayout({
           <main>{children}</main>
           <Toaster />
         </TooltipProvider>
+        <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );


### PR DESCRIPTION
## 概要
Vercel Analytics と Speed Insights を導入し、ページビューと Core Web Vitals を計測できるようにした。

## 変更内容
- `@vercel/analytics` / `@vercel/speed-insights` をインストール
- `app/layout.tsx` に `<Analytics />` と `<SpeedInsights />` を追加（全ページに自動適用）
- `docs/roadmap.md` に Phase 18 として追記

## 確認事項
- [x] セルフレビュー済み