### PR TITLE
fix: 小テスト提出の多重送信防止と受験履歴の最大3件表示に修正

### DIFF
--- a/src/app/(student)/quiz-results/page.tsx
+++ b/src/app/(student)/quiz-results/page.tsx
@@ -110,7 +110,7 @@ function buildTree(attempts: QuizAttemptResult[]): SubjectResult[] {
   const subjectMap = new Map<string, SubjectResult>();
 
   for (const info of lessonInfoMap.values()) {
-    const lessonAttempts = lessonMap.get(info.lessonId) ?? [];
+    const lessonAttempts = (lessonMap.get(info.lessonId) ?? []).slice(0, 3);
     const { recentMaxRate, recentAvgRate } = computeLessonStats(lessonAttempts);
     const frequentlyMissed = computeFrequentlyMissed(lessonAttempts);
 

--- a/src/components/lesson/quiz-section.tsx
+++ b/src/components/lesson/quiz-section.tsx
@@ -303,6 +303,7 @@ export default function QuizSection({ quiz, onCompleted }: Props) {
     quiz.questions.map(initAnswer)
   );
   const [quizState, setQuizState] = useState<QuizState>("answering");
+  const [submitting, setSubmitting] = useState(false);
   const [recentAttempts, setRecentAttempts] = useState<RecentAttemptDetail[]>([]);
 
   useEffect(() => {
@@ -364,6 +365,8 @@ export default function QuizSection({ quiz, onCompleted }: Props) {
   }, [quizState, answers, quiz.questions]);
 
   const handleSubmit = async () => {
+    if (submitting) return;
+    setSubmitting(true);
     setQuizState("submitted");
 
     // 提出内容をAPIに送信して完了フラグを記録
@@ -384,19 +387,23 @@ export default function QuizSection({ quiz, onCompleted }: Props) {
       return { questionId: q.id, type: "ordering" as const, items: ans.items };
     });
 
-    const res = await fetch(`/api/quizzes/${quiz.id}/attempts`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ answers: payload }),
-    });
+    try {
+      const res = await fetch(`/api/quizzes/${quiz.id}/attempts`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ answers: payload }),
+      });
 
-    if (res.ok) {
-      onCompleted?.();
-      const statsRes = await fetch(`/api/quizzes/${quiz.id}/attempts`);
-      if (statsRes.ok) {
-        const json = (await statsRes.json()) as { data: RecentAttemptDetail[] | null };
-        if (json.data) setRecentAttempts(json.data);
+      if (res.ok) {
+        onCompleted?.();
+        const statsRes = await fetch(`/api/quizzes/${quiz.id}/attempts`);
+        if (statsRes.ok) {
+          const json = (await statsRes.json()) as { data: RecentAttemptDetail[] | null };
+          if (json.data) setRecentAttempts(json.data);
+        }
       }
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -481,9 +488,10 @@ export default function QuizSection({ quiz, onCompleted }: Props) {
       {quizState === "answering" ? (
         <button
           onClick={handleSubmit}
-          className="w-full py-2.5 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity"
+          disabled={submitting}
+          className="w-full py-2.5 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          回答を提出する
+          {submitting ? "送信中..." : "回答を提出する"}
         </button>
       ) : (
         <button


### PR DESCRIPTION
## 概要
小テストの提出ボタンの多重送信を防止し、受験履歴の表示を直近3件に統一した。

## 変更内容
- `quiz-section.tsx`: `submitting` state を追加し、送信中はボタンを `disabled` に変更。送信完了（成功・失敗）後に `false` に戻す
- `quiz-section.tsx`: ボタンラベルを送信中は「送信中...」に変更し、`disabled:opacity-50` / `disabled:cursor-not-allowed` を付与
- `quiz-results/page.tsx`: `buildTree()` 内でレッスンごとの `attempts` を `slice(0, 3)` で直近3件に絞り、統計（最高・平均スコア）と間違いが多い問題の計算・受験履歴の表示を3件ベースに統一

## 確認事項
- [x] セルフレビュー済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)