### PR TITLE
refactor: POST/PUTボタンをSubmitButtonコンポーネントに統一して多重送信を防止

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,12 @@
 - クライアントは`lib/supabase/`配下に集約
 - サーバーサイドは`createServerClient`、クライアントは`createBrowserClient`
 
+### ボタン（送信系）
+- サーバーへのデータ書き込みを伴うボタン（POST / PUT）には必ず `SubmitButton` コンポーネント（`src/components/shared/submit-button.tsx`）を使うこと
+  - `loading` prop に通信中フラグを渡すことで、多重送信を自動的に防止する
+  - 呼び出し元で `const [saving, setSaving] = useState(false)` を管理し、通信開始時に `true`・`finally` で `false` をセットする
+- DELETE 系は冪等性があるため通常の `<button>` で可
+
 ### その他
 - `any`型は禁止
 - `console.log`は開発時のみ（コミット前に削除）

--- a/src/components/lesson/memo-section.tsx
+++ b/src/components/lesson/memo-section.tsx
@@ -21,6 +21,7 @@ import { toast } from "sonner";
 import type { Memo } from "@/lib/db/memos";
 import MemoToolbar from "@/components/lesson/memo-toolbar";
 import RichContent from "@/components/shared/rich-content";
+import SubmitButton from "@/components/shared/submit-button";
 
 const lowlight = createLowlight();
 lowlight.register("javascript", javascript);
@@ -58,6 +59,7 @@ export default function MemoSection({ lessonId, getCurrentTime, seekTo, onClose 
   const [editorEmpty, setEditorEmpty] = useState(true);
   const [codeBlockLang, setCodeBlockLang] = useState<string>("");
   const [isCodeBlockActive, setIsCodeBlockActive] = useState(false);
+  const [postingMemoId, setPostingMemoId] = useState<string | null>(null);
 
   const syncEditorState = (editor: Parameters<NonNullable<Parameters<typeof useEditor>[0]["onUpdate"]>>[0]["editor"]) => {
     const active = editor.isActive("codeBlock");
@@ -142,19 +144,24 @@ export default function MemoSection({ lessonId, getCurrentTime, seekTo, onClose 
   };
 
   const handlePost = async (memo: Memo) => {
-    const res = await fetch("/api/posts", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ memoId: memo.id, lessonId, content: memo.content, timestampSeconds: memo.timestamp_seconds }),
-    });
-    if (res.status === 409) {
-      toast.warning("このメモはすでに投稿済みです");
-      return;
-    }
-    if (res.ok) {
-      toast.success("クラスに投稿しました");
-    } else {
-      toast.error("投稿に失敗しました");
+    setPostingMemoId(memo.id);
+    try {
+      const res = await fetch("/api/posts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ memoId: memo.id, lessonId, content: memo.content, timestampSeconds: memo.timestamp_seconds }),
+      });
+      if (res.status === 409) {
+        toast.warning("このメモはすでに投稿済みです");
+        return;
+      }
+      if (res.ok) {
+        toast.success("クラスに投稿しました");
+      } else {
+        toast.error("投稿に失敗しました");
+      }
+    } finally {
+      setPostingMemoId(null);
     }
   };
 
@@ -193,17 +200,15 @@ export default function MemoSection({ lessonId, getCurrentTime, seekTo, onClose 
         <EditorContent editor={editor} />
       </div>
 
-      <button
+      <SubmitButton
+        loading={saveState === "saving"}
+        loadingLabel="保存中..."
+        disabled={!editor || editorEmpty}
         onClick={handleSave}
-        disabled={saveState === "saving" || !editor || editorEmpty}
         className="w-full py-2 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
       >
-        {saveState === "saved"
-          ? "✅ 保存しました！"
-          : saveState === "saving"
-          ? "保存中..."
-          : "保存する"}
-      </button>
+        {saveState === "saved" ? "✅ 保存しました！" : "保存する"}
+      </SubmitButton>
 
       {/* 過去のメモ タイムライン */}
       <div className="pt-1 space-y-2">
@@ -242,12 +247,14 @@ export default function MemoSection({ lessonId, getCurrentTime, seekTo, onClose 
                   </button>
                 </div>
                 <RichContent content={m.content as Record<string, unknown>} />
-                <button
+                <SubmitButton
+                  loading={postingMemoId === m.id}
+                  loadingLabel="投稿中..."
                   onClick={() => handlePost(m)}
-                  className="text-xs px-2 py-1 rounded-md border hover:bg-muted transition-colors"
+                  className="text-xs px-2 py-1 rounded-md border hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   クラスに投稿
-                </button>
+                </SubmitButton>
               </div>
             ))}
           </div>

--- a/src/components/lesson/quiz-section.tsx
+++ b/src/components/lesson/quiz-section.tsx
@@ -19,6 +19,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import RichContent from "@/components/shared/rich-content";
+import SubmitButton from "@/components/shared/submit-button";
 import type { QuizWithQuestions, QuizQuestion } from "@/lib/db/quizzes";
 
 // --------------- 型 ---------------
@@ -486,13 +487,14 @@ export default function QuizSection({ quiz, onCompleted }: Props) {
       </div>
 
       {quizState === "answering" ? (
-        <button
+        <SubmitButton
+          loading={submitting}
+          loadingLabel="送信中..."
           onClick={handleSubmit}
-          disabled={submitting}
           className="w-full py-2.5 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {submitting ? "送信中..." : "回答を提出する"}
-        </button>
+          回答を提出する
+        </SubmitButton>
       ) : (
         <button
           onClick={handleRetry}

--- a/src/components/profile/profile-edit-form.tsx
+++ b/src/components/profile/profile-edit-form.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { toast } from "sonner";
+import SubmitButton from "@/components/shared/submit-button";
 
 type Props = {
   initialStudentNumber: number | null;
@@ -76,13 +77,14 @@ export default function ProfileEditForm({
         />
       </div>
 
-      <button
+      <SubmitButton
         type="submit"
-        disabled={saving}
+        loading={saving}
+        loadingLabel="保存中..."
         className="w-full py-2 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
       >
-        {saving ? "保存中..." : "保存する"}
-      </button>
+        保存する
+      </SubmitButton>
     </form>
   );
 }

--- a/src/components/shared/submit-button.tsx
+++ b/src/components/shared/submit-button.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+/**
+ * POST / PUT 系の送信ボタン共通コンポーネント。
+ * loading={true} の間は自動的に disabled になり、loadingLabel を表示する。
+ * これにより多重送信を防止する。
+ *
+ * 【使用規約】
+ * サーバーへのデータ書き込みを伴うボタン（POST / PUT）には必ずこのコンポーネントを使うこと。
+ * loading state の管理は呼び出し元で行い、通信開始時に true・完了時に false をセットする。
+ */
+
+type Props = {
+  /** 送信中かどうか。true の間はボタンが disabled になり loadingLabel を表示する */
+  loading: boolean;
+  /** 送信中に表示するラベル（省略時: "送信中..."） */
+  loadingLabel?: string;
+  /** loading 以外の理由でボタンを無効化したい場合に使用 */
+  disabled?: boolean;
+  /** クリック時のハンドラ。form の onSubmit で処理する場合は省略可 */
+  onClick?: () => void;
+  /** ボタンの type 属性（省略時: "button"） */
+  type?: "button" | "submit";
+  /** Tailwind クラス。省略時はプライマリボタンのデフォルトスタイルが適用される */
+  className?: string;
+  children: React.ReactNode;
+};
+
+export default function SubmitButton({
+  loading,
+  loadingLabel = "送信中...",
+  disabled = false,
+  onClick,
+  type = "button",
+  className = "w-full py-2.5 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed",
+  children,
+}: Props) {
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={loading || disabled}
+      className={className}
+    >
+      {loading ? loadingLabel : children}
+    </button>
+  );
+}

--- a/src/components/teacher/contents-manager.tsx
+++ b/src/components/teacher/contents-manager.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { toast } from "sonner";
 import type { SubjectWithUnits, Subject, Unit, Lesson } from "@/lib/db/contents";
+import SubmitButton from "@/components/shared/submit-button";
 
 type Props = {
   initialSubjects: SubjectWithUnits[];
@@ -21,39 +22,50 @@ export default function ContentsManager({ initialSubjects }: Props) {
   const [addingUnitForSubjectId, setAddingUnitForSubjectId] = useState<string | null>(null);
   const [newUnitName, setNewUnitName] = useState("");
   const [editing, setEditing] = useState<EditingState>(null);
+  const [saving, setSaving] = useState(false);
 
   // ---- 科目 ----
 
   const handleAddSubject = async () => {
     if (!newSubjectName.trim()) return;
-    const res = await fetch("/api/contents/subjects", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: newSubjectName.trim() }),
-    });
-    const json = (await res.json()) as { data: Subject | null; error: string | null };
-    if (json.data) {
-      setSubjects((prev) => [...prev, { ...json.data!, units: [] }]);
-      setNewSubjectName("");
-      setIsAddingSubject(false);
-    } else {
-      toast.error("科目の追加に失敗しました");
+    setSaving(true);
+    try {
+      const res = await fetch("/api/contents/subjects", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: newSubjectName.trim() }),
+      });
+      const json = (await res.json()) as { data: Subject | null; error: string | null };
+      if (json.data) {
+        setSubjects((prev) => [...prev, { ...json.data!, units: [] }]);
+        setNewSubjectName("");
+        setIsAddingSubject(false);
+      } else {
+        toast.error("科目の追加に失敗しました");
+      }
+    } finally {
+      setSaving(false);
     }
   };
 
   const handleUpdateSubject = async (id: string, name: string) => {
-    const res = await fetch(`/api/contents/subjects/${id}`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name }),
-    });
-    if (res.ok) {
-      setSubjects((prev) =>
-        prev.map((s) => (s.id === id ? { ...s, name } : s))
-      );
-      setEditing(null);
-    } else {
-      toast.error("科目名の変更に失敗しました");
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/contents/subjects/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      if (res.ok) {
+        setSubjects((prev) =>
+          prev.map((s) => (s.id === id ? { ...s, name } : s))
+        );
+        setEditing(null);
+      } else {
+        toast.error("科目名の変更に失敗しました");
+      }
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -101,43 +113,53 @@ export default function ContentsManager({ initialSubjects }: Props) {
 
   const handleAddUnit = async (subjectId: string) => {
     if (!newUnitName.trim()) return;
-    const res = await fetch("/api/contents/units", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ subjectId, name: newUnitName.trim() }),
-    });
-    const json = (await res.json()) as { data: Unit | null; error: string | null };
-    if (json.data) {
-      setSubjects((prev) =>
-        prev.map((s) =>
-          s.id === subjectId
-            ? { ...s, units: [...s.units, { ...json.data!, lessons: [] }] }
-            : s
-        )
-      );
-      setNewUnitName("");
-      setAddingUnitForSubjectId(null);
-    } else {
-      toast.error("単元の追加に失敗しました");
+    setSaving(true);
+    try {
+      const res = await fetch("/api/contents/units", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ subjectId, name: newUnitName.trim() }),
+      });
+      const json = (await res.json()) as { data: Unit | null; error: string | null };
+      if (json.data) {
+        setSubjects((prev) =>
+          prev.map((s) =>
+            s.id === subjectId
+              ? { ...s, units: [...s.units, { ...json.data!, lessons: [] }] }
+              : s
+          )
+        );
+        setNewUnitName("");
+        setAddingUnitForSubjectId(null);
+      } else {
+        toast.error("単元の追加に失敗しました");
+      }
+    } finally {
+      setSaving(false);
     }
   };
 
   const handleUpdateUnit = async (id: string, name: string) => {
-    const res = await fetch(`/api/contents/units/${id}`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name }),
-    });
-    if (res.ok) {
-      setSubjects((prev) =>
-        prev.map((s) => ({
-          ...s,
-          units: s.units.map((u) => (u.id === id ? { ...u, name } : u)),
-        }))
-      );
-      setEditing(null);
-    } else {
-      toast.error("単元名の変更に失敗しました");
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/contents/units/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      if (res.ok) {
+        setSubjects((prev) =>
+          prev.map((s) => ({
+            ...s,
+            units: s.units.map((u) => (u.id === id ? { ...u, name } : u)),
+          }))
+        );
+        setEditing(null);
+      } else {
+        toast.error("単元名の変更に失敗しました");
+      }
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -189,12 +211,14 @@ export default function ContentsManager({ initialSubjects }: Props) {
                       setEditing({ type: "subject", id: subject.id, name: e.target.value })
                     }
                   />
-                  <button
+                  <SubmitButton
                     type="submit"
-                    className="px-3 py-1 text-xs rounded bg-primary text-primary-foreground"
+                    loading={saving}
+                    loadingLabel="保存中..."
+                    className="px-3 py-1 text-xs rounded bg-primary text-primary-foreground disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     保存
-                  </button>
+                  </SubmitButton>
                   <button
                     type="button"
                     onClick={() => setEditing(null)}
@@ -246,12 +270,14 @@ export default function ContentsManager({ initialSubjects }: Props) {
                             setEditing({ type: "unit", id: unit.id, name: e.target.value })
                           }
                         />
-                        <button
+                        <SubmitButton
                           type="submit"
-                          className="px-3 py-1 text-xs rounded bg-primary text-primary-foreground"
+                          loading={saving}
+                          loadingLabel="保存中..."
+                          className="px-3 py-1 text-xs rounded bg-primary text-primary-foreground disabled:opacity-50 disabled:cursor-not-allowed"
                         >
                           保存
-                        </button>
+                        </SubmitButton>
                         <button
                           type="button"
                           onClick={() => setEditing(null)}
@@ -337,12 +363,14 @@ export default function ContentsManager({ initialSubjects }: Props) {
                     value={newUnitName}
                     onChange={(e) => setNewUnitName(e.target.value)}
                   />
-                  <button
+                  <SubmitButton
                     type="submit"
-                    className="px-3 py-1 text-xs rounded bg-primary text-primary-foreground"
+                    loading={saving}
+                    loadingLabel="追加中..."
+                    className="px-3 py-1 text-xs rounded bg-primary text-primary-foreground disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     追加
-                  </button>
+                  </SubmitButton>
                   <button
                     type="button"
                     onClick={() => {
@@ -387,12 +415,14 @@ export default function ContentsManager({ initialSubjects }: Props) {
               value={newSubjectName}
               onChange={(e) => setNewSubjectName(e.target.value)}
             />
-            <button
+            <SubmitButton
               type="submit"
-              className="px-4 py-2 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity"
+              loading={saving}
+              loadingLabel="追加中..."
+              className="px-4 py-2 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
             >
               追加
-            </button>
+            </SubmitButton>
             <button
               type="button"
               onClick={() => {

--- a/src/components/teacher/lesson-new-form.tsx
+++ b/src/components/teacher/lesson-new-form.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import type { SubjectWithUnits } from "@/lib/db/contents";
+import SubmitButton from "@/components/shared/submit-button";
 
 type QuestionInput = {
   id: string;
@@ -239,13 +240,14 @@ export default function LessonNewForm({ subjects, defaultUnitId }: Props) {
         </div>
 
         {/* 保存ボタン */}
-        <button
+        <SubmitButton
+          loading={isSaving}
+          loadingLabel="登録中..."
           onClick={handleSave}
-          disabled={isSaving}
           className="w-full py-2.5 rounded-md bg-primary text-primary-foreground font-medium hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          {isSaving ? "登録中..." : "保存する"}
-        </button>
+          保存する
+        </SubmitButton>
       </div>
     </div>
   );

--- a/src/components/teacher/quiz-existing.tsx
+++ b/src/components/teacher/quiz-existing.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import type { QuizWithQuestions, QuizQuestion, QuizQuestionType } from "@/lib/db/quizzes";
 import RichContent from "@/components/shared/rich-content";
 import QuizQuestionEditor from "@/components/teacher/quiz-question-editor";
+import SubmitButton from "@/components/shared/submit-button";
 
 // --------------- 定数 ---------------
 
@@ -351,14 +352,14 @@ function AddQuestionForm({ quizId, formKey, onAdded, onCancel }: AddQuestionForm
       </div>
 
       <div className="flex gap-2 pt-1">
-        <button
-          type="button"
+        <SubmitButton
+          loading={saving}
+          loadingLabel="追加中..."
           onClick={handleAdd}
-          disabled={saving}
-          className="flex-1 py-2 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-40"
+          className="flex-1 py-2 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          {saving ? "追加中..." : "問題を追加する"}
-        </button>
+          問題を追加する
+        </SubmitButton>
         <button
           type="button"
           onClick={onCancel}

--- a/src/components/teacher/quiz-form.tsx
+++ b/src/components/teacher/quiz-form.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import QuizQuestionEditor from "@/components/teacher/quiz-question-editor";
 import type { QuizQuestionType } from "@/lib/db/quizzes";
 import { textToTiptapDoc } from "@/lib/tiptap-utils";
+import SubmitButton from "@/components/shared/submit-button";
 
 const QUESTION_TYPE_LABELS: Record<QuizQuestionType, string> = {
   multiple_choice: "選択式",
@@ -464,14 +465,14 @@ export default function QuizForm({ lessonId }: Props) {
         + 問題を追加
       </button>
 
-      <button
-        type="button"
+      <SubmitButton
+        loading={saving}
+        loadingLabel="保存中..."
         onClick={handleSubmit}
-        disabled={saving}
         className="w-full py-2 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
       >
-        {saving ? "保存中..." : "クイズを保存する"}
-      </button>
+        クイズを保存する
+      </SubmitButton>
     </div>
   );
 }

--- a/src/components/teacher/students-table.tsx
+++ b/src/components/teacher/students-table.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from "react";
 import { toast } from "sonner";
 import type { Profile } from "@/lib/db/users";
+import SubmitButton from "@/components/shared/submit-button";
 
 type SortKey = "student_number" | "display_name";
 type SortOrder = "asc" | "desc";
@@ -299,13 +300,14 @@ export default function StudentsTable({ initialProfiles }: Props) {
                   <td className="px-4 py-2.5">
                     {isEditing ? (
                       <div className="flex gap-1.5">
-                        <button
+                        <SubmitButton
+                          loading={saving}
+                          loadingLabel="…"
                           onClick={handleSave}
-                          disabled={saving}
-                          className="text-xs px-2 py-1 rounded bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-40"
+                          className="text-xs px-2 py-1 rounded bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
                         >
-                          {saving ? "…" : "保存"}
-                        </button>
+                          保存
+                        </SubmitButton>
                         <button
                           onClick={cancelEdit}
                           disabled={saving}


### PR DESCRIPTION
## 概要
POST/PUT系のボタンを共通の `SubmitButton` コンポーネントに統一し、多重送信を体系的に防止する仕組みを整備した。

## 変更内容
- `src/components/shared/submit-button.tsx` を新規作成
  - `loading` prop が `true` の間は自動的に `disabled` になり `loadingLabel` を表示する
  - `className` のデフォルトはプライマリボタンスタイル（省略可能）
- 以下の全 POST/PUT ボタンを `SubmitButton` に置き換え
  - `memo-section.tsx`: 「保存する」「クラスに投稿」（後者は `postingMemoId` state を新規追加）
  - `profile-edit-form.tsx`: 「保存する」
  - `lesson-new-form.tsx`: 「保存する」
  - `quiz-form.tsx`: 「クイズを保存する」
  - `students-table.tsx`: 「保存」
  - `quiz-existing.tsx`: 「問題を追加する」
  - `quiz-section.tsx`: 「回答を提出する」
  - `contents-manager.tsx`: 科目「保存」「追加」、単元「保存」「追加」（`saving` state を新規追加）
- `CLAUDE.md` に「POST/PUT系ボタンには `SubmitButton` を使うこと」を規約として追記

## 確認事項
- [x] セルフレビュー済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)