### PR TITLE
chore: .claude/worktrees/ を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ next-env.d.ts
 
 # supabase studio snippets (auto-synced, not part of codebase)
 /supabase/snippets/
+
+# claude code worktrees (temporary isolated workspaces created by claude agents)
+.claude/worktrees/


### PR DESCRIPTION
## 概要
Claude Code の Agent ツールが自動生成する一時的な git worktree ディレクトリを .gitignore に追加した。

## 変更内容
- `.gitignore` に `.claude/worktrees/` を追加

## 確認事項
- [x] セルフレビュー済み