### PR TITLE
feat: メモエクスポート機能を追加（Phase 19 タスクC）

### DIFF
--- a/src/app/api/teacher/units/[unitId]/memo-export/route.ts
+++ b/src/app/api/teacher/units/[unitId]/memo-export/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import {
+  getUnitMemoSamplesForExport,
+  type UnitMemoExportData,
+} from "@/lib/db/memos";
+
+function escapeCsv(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function generateCsv(data: UnitMemoExportData): string {
+  const lines: string[] = [];
+
+  lines.push(
+    `## 対象: ${data.grade}年全体 ${data.studentCount}名 / 出力日: ${data.exportDate}`
+  );
+  lines.push("");
+
+  lines.push("## 授業別メモサンプル（ランダム10人分/授業・複数メモは結合）");
+  lines.push(["レッスン", "メモ内容（結合・要約）"].map(escapeCsv).join(","));
+
+  for (const lesson of data.lessons) {
+    for (const memo of lesson.memos) {
+      lines.push([lesson.lessonTitle, memo].map(escapeCsv).join(","));
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ unitId: string }> }
+) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  if (profile?.role !== "teacher" && profile?.role !== "admin") {
+    return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
+  }
+
+  const { unitId } = await params;
+  const gradeRaw = req.nextUrl.searchParams.get("grade");
+
+  if (!gradeRaw) {
+    return NextResponse.json(
+      { data: null, error: "grade は必須です" },
+      { status: 400 }
+    );
+  }
+
+  const grade = parseInt(gradeRaw, 10);
+  if (isNaN(grade) || grade < 1 || grade > 3) {
+    return NextResponse.json(
+      { data: null, error: "grade が不正です" },
+      { status: 400 }
+    );
+  }
+
+  const data = await getUnitMemoSamplesForExport(unitId, grade);
+
+  if (!data) {
+    return NextResponse.json(
+      { data: null, error: "データが見つかりませんでした" },
+      { status: 404 }
+    );
+  }
+
+  const csv = generateCsv(data);
+  const safeUnitName = data.unitName.replace(/[\\/:*?"<>|]/g, "_");
+  const filename = `memo_export_${safeUnitName}_${data.grade}年_${data.exportDate}.csv`;
+
+  return new NextResponse(csv, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="${encodeURIComponent(filename)}"`,
+    },
+  });
+}

--- a/src/components/teacher/data-export.tsx
+++ b/src/components/teacher/data-export.tsx
@@ -6,11 +6,15 @@ import type { SubjectWithUnits } from "@/lib/db/contents";
 
 const GRADES = [1, 2, 3] as const;
 
-const AI_PROMPT_TEMPLATE = `【実施した単元の計画】
+const QUIZ_AI_PROMPT_TEMPLATE = `【実施した単元の計画】
 （ここに単元計画を貼り付ける）
 
 【小テスト結果】
 （ダウンロードしたCSVファイルを添付、または以下の文章を削除してここに貼り付ける）
+添付のCSVファイルを参照
+
+【生徒のメモ】
+（メモエクスポートのCSVファイルを添付、または以下の文章を削除してここに貼り付ける）
 添付のCSVファイルを参照
 
 【次回の単元について】
@@ -25,6 +29,19 @@ const AI_PROMPT_TEMPLATE = `【実施した単元の計画】
 - 生徒の興味関心
 また、考察を踏まえて次回の単元に向けた改善案や実施上の注意点を挙げてください。`;
 
+const MEMO_AI_PROMPT_TEMPLATE = `【実施した単元の計画】
+（ここに単元計画を貼り付ける）
+
+【生徒のメモ】
+（ダウンロードしたCSVファイルを添付、または以下の文章を削除してここに貼り付ける）
+添付のCSVファイルを参照
+
+---
+以上のデータをもとに、実施した単元について以下の観点で考察してください。
+- 生徒が理解できていたこと・できていなかったこと
+- 生徒の興味関心の傾向
+また、考察を踏まえて次回の単元に向けた改善案や実施上の注意点を挙げてください。`;
+
 type Props = {
   subjects: SubjectWithUnits[];
 };
@@ -33,8 +50,10 @@ export default function DataExport({ subjects }: Props) {
   const [grade, setGrade] = useState<number | "">("");
   const [subjectId, setSubjectId] = useState("");
   const [unitId, setUnitId] = useState("");
-  const [showPrompt, setShowPrompt] = useState(false);
-  const [downloading, setDownloading] = useState(false);
+  const [showQuizPrompt, setShowQuizPrompt] = useState(false);
+  const [showMemoPrompt, setShowMemoPrompt] = useState(false);
+  const [downloadingQuiz, setDownloadingQuiz] = useState(false);
+  const [downloadingMemo, setDownloadingMemo] = useState(false);
 
   const selectedSubject = subjects.find((s) => s.id === subjectId);
   const units = selectedSubject?.units ?? [];
@@ -46,11 +65,13 @@ export default function DataExport({ subjects }: Props) {
 
   const canDownload = grade !== "" && subjectId !== "" && unitId !== "";
 
-  const handleDownload = async () => {
-    if (!canDownload) return;
-    setDownloading(true);
+  const downloadCsv = async (
+    url: string,
+    fallbackFilename: string,
+    setLoading: (v: boolean) => void
+  ) => {
+    setLoading(true);
     try {
-      const url = `/api/teacher/units/${unitId}/quiz-export?grade=${grade}`;
       const res = await fetch(url);
       if (!res.ok) {
         const json = (await res.json()) as { error?: string };
@@ -63,7 +84,7 @@ export default function DataExport({ subjects }: Props) {
       link.href = blobUrl;
       const disposition = res.headers.get("Content-Disposition") ?? "";
       const match = disposition.match(/filename="([^"]+)"/);
-      link.download = match ? decodeURIComponent(match[1]) : "quiz_export.csv";
+      link.download = match ? decodeURIComponent(match[1]) : fallbackFilename;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
@@ -72,13 +93,27 @@ export default function DataExport({ subjects }: Props) {
     } catch {
       toast.error("エクスポートに失敗しました");
     } finally {
-      setDownloading(false);
+      setLoading(false);
     }
   };
 
-  const handleCopyPrompt = async () => {
+  const handleDownloadQuiz = () =>
+    downloadCsv(
+      `/api/teacher/units/${unitId}/quiz-export?grade=${grade}`,
+      "quiz_export.csv",
+      setDownloadingQuiz
+    );
+
+  const handleDownloadMemo = () =>
+    downloadCsv(
+      `/api/teacher/units/${unitId}/memo-export?grade=${grade}`,
+      "memo_export.csv",
+      setDownloadingMemo
+    );
+
+  const handleCopy = async (text: string) => {
     try {
-      await navigator.clipboard.writeText(AI_PROMPT_TEMPLATE);
+      await navigator.clipboard.writeText(text);
       toast.success("コピーしました");
     } catch {
       toast.error("コピーに失敗しました");
@@ -87,16 +122,14 @@ export default function DataExport({ subjects }: Props) {
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
-      {/* 小テスト結果 */}
-      <div className="rounded-lg border bg-card p-6 space-y-5">
+      {/* 共通セレクタ */}
+      <div className="rounded-lg border bg-card p-6 space-y-4">
         <div>
-          <h2 className="text-base font-semibold">小テスト結果</h2>
+          <h2 className="text-base font-semibold">対象を選択</h2>
           <p className="text-sm text-muted-foreground mt-0.5">
-            単元の小テスト結果を AI が読み込みやすい CSV 形式でダウンロードします。
-            各生徒の最新受験のみを集計します。
+            エクスポートする学年・科目・単元を選択してください。
           </p>
         </div>
-
         <div className="grid grid-cols-3 gap-4">
           <div className="space-y-1.5">
             <label className="text-sm font-medium">学年</label>
@@ -149,44 +182,94 @@ export default function DataExport({ subjects }: Props) {
             </select>
           </div>
         </div>
+      </div>
+
+      {/* 小テスト結果 */}
+      <div className="rounded-lg border bg-card p-6 space-y-5">
+        <div>
+          <h2 className="text-base font-semibold">小テスト結果</h2>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            単元の小テスト結果を AI が読み込みやすい CSV 形式でダウンロードします。
+            各生徒の最新受験のみを集計します。
+          </p>
+        </div>
 
         <div className="flex items-center gap-3 flex-wrap">
           <button
-            onClick={handleDownload}
-            disabled={!canDownload || downloading}
+            onClick={handleDownloadQuiz}
+            disabled={!canDownload || downloadingQuiz}
             className="px-4 py-2 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
           >
-            {downloading ? "ダウンロード中..." : "CSV をダウンロード"}
+            {downloadingQuiz ? "ダウンロード中..." : "CSV をダウンロード"}
           </button>
           <button
-            onClick={() => setShowPrompt((v) => !v)}
+            onClick={() => setShowQuizPrompt((v) => !v)}
             className="px-4 py-2 text-sm rounded-md border hover:bg-muted transition-colors"
           >
-            {showPrompt ? "▲ AI プロンプトを隠す" : "▼ AI プロンプトを表示"}
+            {showQuizPrompt ? "▲ AI プロンプトを隠す" : "▼ AI プロンプトを表示"}
           </button>
         </div>
 
-        {showPrompt && (
+        {showQuizPrompt && (
           <div className="rounded-md border bg-muted/30 p-4 space-y-3">
             <div className="flex items-center justify-between">
               <span className="text-sm font-medium">AI 分析プロンプトテンプレート</span>
               <button
-                onClick={handleCopyPrompt}
+                onClick={() => handleCopy(QUIZ_AI_PROMPT_TEMPLATE)}
                 className="text-xs px-3 py-1 rounded border hover:bg-muted transition-colors"
               >
                 コピー
               </button>
             </div>
             <pre className="text-xs text-muted-foreground whitespace-pre-wrap font-mono leading-relaxed">
-              {AI_PROMPT_TEMPLATE}
+              {QUIZ_AI_PROMPT_TEMPLATE}
             </pre>
           </div>
         )}
       </div>
 
-      {/* 将来の拡張セクション（プレースホルダー） */}
-      <div className="rounded-lg border border-dashed bg-muted/20 p-6 text-center text-sm text-muted-foreground">
-        動画視聴履歴・メモデータのエクスポートは今後追加予定です
+      {/* 生徒のメモサンプル */}
+      <div className="rounded-lg border bg-card p-6 space-y-5">
+        <div>
+          <h2 className="text-base font-semibold">生徒のメモサンプル</h2>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            単元内の各レッスンで生徒が残したメモをランダムにサンプリングして CSV でダウンロードします。
+            レッスンごとに最大10人分・複数メモは結合して出力します。
+          </p>
+        </div>
+
+        <div className="flex items-center gap-3 flex-wrap">
+          <button
+            onClick={handleDownloadMemo}
+            disabled={!canDownload || downloadingMemo}
+            className="px-4 py-2 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
+          >
+            {downloadingMemo ? "ダウンロード中..." : "CSV をダウンロード"}
+          </button>
+          <button
+            onClick={() => setShowMemoPrompt((v) => !v)}
+            className="px-4 py-2 text-sm rounded-md border hover:bg-muted transition-colors"
+          >
+            {showMemoPrompt ? "▲ AI プロンプトを隠す" : "▼ AI プロンプトを表示"}
+          </button>
+        </div>
+
+        {showMemoPrompt && (
+          <div className="rounded-md border bg-muted/30 p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">AI 分析プロンプトテンプレート</span>
+              <button
+                onClick={() => handleCopy(MEMO_AI_PROMPT_TEMPLATE)}
+                className="text-xs px-3 py-1 rounded border hover:bg-muted transition-colors"
+              >
+                コピー
+              </button>
+            </div>
+            <pre className="text-xs text-muted-foreground whitespace-pre-wrap font-mono leading-relaxed">
+              {MEMO_AI_PROMPT_TEMPLATE}
+            </pre>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/lib/db/memos.ts
+++ b/src/lib/db/memos.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import type { Database } from "@/lib/supabase/types";
+import { tiptapDocToText } from "@/lib/tiptap-utils";
 
 export type Memo = Database["public"]["Tables"]["memos"]["Row"] & {
   content: TiptapContent;
@@ -179,6 +180,133 @@ export async function getMemosByStudent(
 
   if (error || !data) return [];
   return data as Memo[];
+}
+
+export type LessonMemoSample = {
+  lessonTitle: string;
+  memos: string[];
+};
+
+export type UnitMemoExportData = {
+  unitName: string;
+  grade: number;
+  studentCount: number;
+  exportDate: string;
+  lessons: LessonMemoSample[];
+};
+
+/**
+ * 単元内の各レッスンで対象学年の生徒が書いたメモをサンプリングして返す（teacher/admin 向け）
+ * - レッスンごとにメモを1件以上書いた生徒からランダムに最大10人を抽出
+ * - 同一生徒の複数メモは「／」で結合し300文字で切り詰め
+ * - 学籍番号・氏名は含めない
+ */
+export async function getUnitMemoSamplesForExport(
+  unitId: string,
+  grade: number
+): Promise<UnitMemoExportData | null> {
+  const supabase = await createClient();
+
+  const { data: unit } = await supabase
+    .from("units")
+    .select("name")
+    .eq("id", unitId)
+    .single();
+  if (!unit) return null;
+
+  const { data: lessons } = await supabase
+    .from("lessons")
+    .select("id, title, order")
+    .eq("unit_id", unitId)
+    .order("order");
+  if (!lessons || lessons.length === 0) return null;
+
+  const lessonIds = lessons.map((l) => l.id);
+
+  const { data: profiles } = await supabase
+    .from("profiles")
+    .select("id, student_number")
+    .eq("role", "student")
+    .not("student_number", "is", null)
+    .gte("student_number", grade * 1000)
+    .lte("student_number", grade * 1000 + 999)
+    .limit(2000);
+
+  const students = profiles ?? [];
+  const studentIds = students.map((p) => p.id);
+
+  const exportDate = new Date().toISOString().slice(0, 10);
+
+  if (studentIds.length === 0) {
+    return { unitName: unit.name, grade, studentCount: 0, exportDate, lessons: [] };
+  }
+
+  type MemoRow = {
+    lesson_id: string;
+    user_id: string;
+    content: unknown;
+    created_at: string;
+  };
+
+  const allMemos: MemoRow[] = [];
+  const CHUNK_SIZE = 100;
+  for (let i = 0; i < studentIds.length; i += CHUNK_SIZE) {
+    const chunk = studentIds.slice(i, i + CHUNK_SIZE);
+    const { data: chunkMemos } = await supabase
+      .from("memos")
+      .select("lesson_id, user_id, content, created_at")
+      .in("lesson_id", lessonIds)
+      .in("user_id", chunk)
+      .order("created_at", { ascending: true });
+    if (chunkMemos) allMemos.push(...(chunkMemos as MemoRow[]));
+  }
+
+  // レッスン × ユーザーごとにメモをグループ化
+  const memosByLessonUser = new Map<string, Map<string, MemoRow[]>>();
+  for (const memo of allMemos) {
+    if (!memosByLessonUser.has(memo.lesson_id)) {
+      memosByLessonUser.set(memo.lesson_id, new Map());
+    }
+    const byUser = memosByLessonUser.get(memo.lesson_id)!;
+    const existing = byUser.get(memo.user_id) ?? [];
+    existing.push(memo);
+    byUser.set(memo.user_id, existing);
+  }
+
+  const MAX_SAMPLES = 10;
+  const MAX_CHARS = 300;
+
+  const lessonSamples: LessonMemoSample[] = [];
+
+  for (const lesson of lessons) {
+    const byUser = memosByLessonUser.get(lesson.id);
+    if (!byUser || byUser.size === 0) continue;
+
+    const usersWithMemos = Array.from(byUser.keys());
+    // Fisher–Yates シャッフル
+    for (let i = usersWithMemos.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [usersWithMemos[i], usersWithMemos[j]] = [usersWithMemos[j], usersWithMemos[i]];
+    }
+    const sampled = usersWithMemos.slice(0, MAX_SAMPLES);
+
+    const memoTexts: string[] = [];
+    for (const userId of sampled) {
+      const userMemos = byUser.get(userId) ?? [];
+      const texts = userMemos
+        .map((m) => tiptapDocToText(m.content as Record<string, unknown>).trim())
+        .filter((t) => t.length > 0);
+      if (texts.length === 0) continue;
+      const merged = texts.join("／");
+      const truncated = merged.length > MAX_CHARS ? merged.slice(0, MAX_CHARS) + "…" : merged;
+      memoTexts.push(truncated);
+    }
+
+    if (memoTexts.length === 0) continue;
+    lessonSamples.push({ lessonTitle: lesson.title, memos: memoTexts });
+  }
+
+  return { unitName: unit.name, grade, studentCount: students.length, exportDate, lessons: lessonSamples };
 }
 
 /**


### PR DESCRIPTION
## 概要
Phase 19「データの利活用」タスクCとして、生徒のメモをサンプリングしてCSVエクスポートする機能を実装した。あわせて小テスト用AIプロンプトテンプレートに【生徒のメモ】欄を追加し、セレクタを両エクスポートで共通化した。

## 変更内容
- `src/lib/db/memos.ts` に `getUnitMemoSamplesForExport(unitId, grade)` を追加
  - 対象学年の生徒をフィルタリング（student_number 範囲）
  - レッスンごとにメモ有り生徒からランダム最大10人を抽出（Fisher–Yates シャッフル）
  - 同一生徒の複数メモを「／」で結合 → tiptap JSON → プレーンテキスト → 300文字切り詰め
  - 学籍番号・氏名は含めない
  - 生徒IDのチャンク分割クエリ（100件ずつ）で URL 長制限に対応
- `src/app/api/teacher/units/[unitId]/memo-export/route.ts` を新規作成
  - teacher/admin のみアクセス可
  - CSV 形式レスポンス（`Content-Disposition: attachment`）
- `src/components/teacher/data-export.tsx` を更新
  - 学年/科目/単元セレクタを両セクション共通のカードに切り出し
  - 「生徒のメモサンプル」エクスポートセクションを追加（ダウンロードボタン + AI プロンプトコピー UI）
  - 小テスト用プロンプトテンプレートに【生徒のメモ】欄を追加

## 確認事項
- [x] セルフレビュー済み