### PR TITLE
fix: ミドルウェアのファイル名修正とAuth呼び出しの重複排除

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,20 +1,18 @@
 import { redirect } from "next/navigation";
-import { createClient } from "@/lib/supabase/server";
+import { createClient, getUser } from "@/lib/supabase/server";
 
 export default async function AdminLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const user = await getUser();
 
   if (!user) {
     redirect("/login");
   }
 
+  const supabase = await createClient();
   const { data: profile } = await supabase
     .from("profiles")
     .select("role")

--- a/src/app/(student)/layout.tsx
+++ b/src/app/(student)/layout.tsx
@@ -1,15 +1,12 @@
 import { redirect } from "next/navigation";
-import { createClient } from "@/lib/supabase/server";
+import { getUser } from "@/lib/supabase/server";
 
 export default async function StudentLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const user = await getUser();
 
   if (!user) {
     redirect("/login");

--- a/src/app/(teacher)/layout.tsx
+++ b/src/app/(teacher)/layout.tsx
@@ -1,20 +1,18 @@
 import { redirect } from "next/navigation";
-import { createClient } from "@/lib/supabase/server";
+import { createClient, getUser } from "@/lib/supabase/server";
 
 export default async function TeacherLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const user = await getUser();
 
   if (!user) {
     redirect("/login");
   }
 
+  const supabase = await createClient();
   const { data: profile } = await supabase
     .from("profiles")
     .select("role")

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
+import { cache } from "react";
 
 export async function createClient() {
   const cookieStore = await cookies();
@@ -38,3 +39,11 @@ export async function createClient() {
     }
   );
 }
+
+export const getUser = cache(async () => {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  return user;
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import { type NextRequest } from "next/server";
 import { updateSession } from "@/lib/supabase/middleware";
 
-export async function proxy(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   return await updateSession(request);
 }
 


### PR DESCRIPTION
## 概要
`proxy.ts`（Next.jsに認識されないファイル名）を`middleware.ts`に修正し、ミドルウェアを正しく機能させる。あわせてReact `cache()`を用いて同一リクエスト内でのAuth呼び出しを重複排除し、授業時間帯の同時アクセスによるSupabase Auth（GoTrue）への負荷を削減する。

## 変更内容
- `src/proxy.ts` を削除し `src/middleware.ts` として再作成（エクスポート関数名を `proxy` → `middleware` に修正）
- `src/lib/supabase/server.ts` に React `cache()` でラップした `getUser` を追加
- `src/app/(student)/layout.tsx`：`createClient()` + `supabase.auth.getUser()` → `getUser()` に置き換え
- `src/app/(teacher)/layout.tsx`：同上（DBクエリ用の `createClient()` は維持）
- `src/app/(admin)/layout.tsx`：同上

## 確認事項
- [x] セルフレビュー済み