### PR TITLE
refactor: APIルートのAuth呼び出しをgetSession()に変更

### DIFF
--- a/src/app/api/contents/lessons/[lessonId]/route.ts
+++ b/src/app/api/contents/lessons/[lessonId]/route.ts
@@ -5,8 +5,9 @@ import { createClient } from "@/lib/supabase/server";
 async function requireTeacher() {
   const supabase = await createClient();
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
   if (!user) return null;
 
   const { data: profile } = await supabase

--- a/src/app/api/contents/lessons/route.ts
+++ b/src/app/api/contents/lessons/route.ts
@@ -5,8 +5,9 @@ import { createClient } from "@/lib/supabase/server";
 export async function POST(request: NextRequest) {
   const supabase = await createClient();
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
 
   if (!user) {
     return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/contents/subjects/[subjectId]/route.ts
+++ b/src/app/api/contents/subjects/[subjectId]/route.ts
@@ -5,8 +5,9 @@ import { createClient } from "@/lib/supabase/server";
 async function requireTeacher() {
   const supabase = await createClient();
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
   if (!user) return null;
 
   const { data: profile } = await supabase

--- a/src/app/api/contents/subjects/route.ts
+++ b/src/app/api/contents/subjects/route.ts
@@ -5,8 +5,9 @@ import { createClient } from "@/lib/supabase/server";
 async function requireTeacher() {
   const supabase = await createClient();
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
   if (!user) return null;
 
   const { data: profile } = await supabase

--- a/src/app/api/contents/units/[unitId]/route.ts
+++ b/src/app/api/contents/units/[unitId]/route.ts
@@ -5,8 +5,9 @@ import { createClient } from "@/lib/supabase/server";
 async function requireTeacher() {
   const supabase = await createClient();
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
   if (!user) return null;
 
   const { data: profile } = await supabase

--- a/src/app/api/contents/units/route.ts
+++ b/src/app/api/contents/units/route.ts
@@ -5,8 +5,9 @@ import { createClient } from "@/lib/supabase/server";
 async function requireTeacher() {
   const supabase = await createClient();
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
   if (!user) return null;
 
   const { data: profile } = await supabase

--- a/src/app/api/images/[fileId]/route.ts
+++ b/src/app/api/images/[fileId]/route.ts
@@ -6,8 +6,9 @@ type Params = { params: Promise<{ fileId: string }> };
 export async function DELETE(req: NextRequest, { params }: Params) {
   const supabase = await createClient();
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
   if (!user) {
     return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
   }

--- a/src/app/api/images/upload/route.ts
+++ b/src/app/api/images/upload/route.ts
@@ -6,8 +6,9 @@ const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 export async function POST(req: NextRequest) {
   const supabase = await createClient();
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
   if (!user) {
     return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
   }

--- a/src/app/api/posts/[postId]/route.ts
+++ b/src/app/api/posts/[postId]/route.ts
@@ -8,7 +8,8 @@ export async function DELETE(
 ) {
   const { postId } = await params;
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: { session } } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
   if (!user) return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
 
   const success = await deletePost(postId);

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -15,7 +15,8 @@ export async function GET(request: NextRequest) {
   }
 
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: { session } } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
 
   if (user) {
     const { data: profile } = await supabase

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -11,8 +11,9 @@ type UpdateProfileBody = {
 export async function PUT(req: Request) {
   const supabase = await createClient();
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
 
   if (!user) {
     return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/quiz-questions/[questionId]/route.ts
+++ b/src/app/api/quiz-questions/[questionId]/route.ts
@@ -9,8 +9,9 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
 
   const supabase = await createClient();
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
   if (!user) return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
 
   const { data: profile } = await supabase

--- a/src/app/api/quizzes/[quizId]/attempts/route.ts
+++ b/src/app/api/quizzes/[quizId]/attempts/route.ts
@@ -13,7 +13,8 @@ type Params = { params: Promise<{ quizId: string }> };
 export async function GET(_req: NextRequest, { params }: Params) {
   const { quizId } = await params;
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: { session } } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
   if (!user) return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
 
   const attempts = await getRecentQuizAttemptsWithAnswers(quizId, user.id);
@@ -23,7 +24,8 @@ export async function GET(_req: NextRequest, { params }: Params) {
 export async function POST(req: NextRequest, { params }: Params) {
   const { quizId } = await params;
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: { session } } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
   if (!user) return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
 
   const body = (await req.json()) as { answers: AnswerPayload[] };

--- a/src/app/api/quizzes/[quizId]/questions/route.ts
+++ b/src/app/api/quizzes/[quizId]/questions/route.ts
@@ -21,8 +21,9 @@ export async function POST(req: NextRequest, { params }: Params) {
 
   const supabase = await createClient();
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
   if (!user) return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
 
   const { data: profile } = await supabase

--- a/src/app/api/quizzes/[quizId]/route.ts
+++ b/src/app/api/quizzes/[quizId]/route.ts
@@ -9,8 +9,9 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
 
   const supabase = await createClient();
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
   if (!user) return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
 
   const { data: profile } = await supabase

--- a/src/app/api/quizzes/route.ts
+++ b/src/app/api/quizzes/route.ts
@@ -23,8 +23,9 @@ type CreateQuizPayload = {
 export async function POST(req: NextRequest) {
   const supabase = await createClient();
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
   if (!user) return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
 
   const { data: profile } = await supabase

--- a/src/app/api/teacher/lessons/[lessonId]/memo-students/[userId]/route.ts
+++ b/src/app/api/teacher/lessons/[lessonId]/memo-students/[userId]/route.ts
@@ -8,8 +8,9 @@ export async function GET(_req: NextRequest, { params }: Params) {
   const { lessonId, userId } = await params;
   const supabase = await createClient();
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
   if (!user) {
     return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
   }

--- a/src/app/api/teacher/lessons/[lessonId]/memo-students/route.ts
+++ b/src/app/api/teacher/lessons/[lessonId]/memo-students/route.ts
@@ -8,8 +8,9 @@ export async function GET(req: NextRequest, { params }: Params) {
   const { lessonId } = await params;
   const supabase = await createClient();
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
   if (!user) {
     return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
   }

--- a/src/app/api/teacher/quiz-analytics/route.ts
+++ b/src/app/api/teacher/quiz-analytics/route.ts
@@ -5,8 +5,9 @@ import { getQuizAnalytics } from "@/lib/db/quizzes";
 export async function GET(req: NextRequest) {
   const supabase = await createClient();
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
   if (!user) {
     return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
   }

--- a/src/app/api/teacher/units/[unitId]/memo-export/route.ts
+++ b/src/app/api/teacher/units/[unitId]/memo-export/route.ts
@@ -38,8 +38,9 @@ export async function GET(
 ) {
   const supabase = await createClient();
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
 
   if (!user) {
     return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/teacher/units/[unitId]/quiz-export/route.ts
+++ b/src/app/api/teacher/units/[unitId]/quiz-export/route.ts
@@ -143,8 +143,9 @@ export async function GET(
 ) {
   const supabase = await createClient();
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user ?? null;
 
   if (!user) {
     return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });


### PR DESCRIPTION
## 概要
全21本のAPIルートで `supabase.auth.getUser()` を `supabase.auth.getSession()` に置き換え、授業時間帯の同時アクセス時に発生するSupabase Auth（GoTrue）への負荷を削減する。

## 変更内容
- `src/app/api/` 配下の全21ファイルで `getUser()` → `getSession()` に置き換え
  - `const { data: { session } } = await supabase.auth.getSession();`
  - `const user = session?.user ?? null;` の形に統一
- 対象ディレクトリ: `contents/`, `images/`, `profile/`, `quiz-questions/`, `posts/`, `quizzes/`, `teacher/`
- middleware・layout での `getUser()` はサーバー検証が必要なため変更なし

## 確認事項
- [x] セルフレビュー済み