### PR TITLE
fix: Next.js 16の仕様に合わせてmiddleware.tsをproxy.tsに戻す

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,7 @@
 import { type NextRequest } from "next/server";
 import { updateSession } from "@/lib/supabase/middleware";
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   return await updateSession(request);
 }
 


### PR DESCRIPTION
## 概要
Next.js 16 で middleware ファイルの規約が `proxy.ts` + `export function proxy(...)` に変更されたため、誤って `middleware.ts` に変更していたファイルを正しい規約に戻す。

## 変更内容
- `src/middleware.ts` を削除し `src/proxy.ts` として再作成
- エクスポート関数名を `middleware` → `proxy` に修正
- ロジック・matcher 設定の変更なし

## 背景
Next.js 16 から "middleware" という名称が "proxy" に変更された（Edge Runtime の廃止、Node.js ランタイム固定）。  
参考: [Renaming Middleware to Proxy | Next.js](https://nextjs.org/docs/messages/middleware-to-proxy)

## 確認事項
- [x] セルフレビュー済み