### PR TITLE
chore: ローカル開発用の OAuth リダイレクト URL を追加

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -302,6 +302,7 @@ max_frequency = "5s"
 enabled = true
 client_id = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID)"
 secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET)"
+redirect_uri = "http://127.0.0.1:54321/auth/v1/callback"
 skip_nonce_check = true
 
 [auth.external.apple]

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -149,7 +149,7 @@ enabled = true
 # in emails.
 site_url = "http://localhost:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["http://localhost:3000", "https://localhost:3000"]
+additional_redirect_urls = ["http://localhost:3000", "https://localhost:3000", "http://localhost:3000/auth/callback"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).


### PR DESCRIPTION
## 概要
`supabase/config.toml` の `additional_redirect_urls` に `/auth/callback` を追加し、開発環境での Google OAuth ログインが正常に動作するよう修正する。

## 変更内容
- `additional_redirect_urls` に `http://localhost:3000/auth/callback` を追加

## 確認事項
- [ ] セルフレビュー済み