### PR TITLE
refactor: Supabase 無料枠の通信量超過対策（認証・DBリクエスト削減）

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,25 +1,18 @@
 import { redirect } from "next/navigation";
-import { createClient, getUser } from "@/lib/supabase/server";
+import { getUserProfile } from "@/lib/supabase/server";
 
 export default async function AdminLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const user = await getUser();
+  const profile = await getUserProfile();
 
-  if (!user) {
+  if (!profile) {
     redirect("/login");
   }
 
-  const supabase = await createClient();
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (profile?.role !== "admin") {
+  if (profile.role !== "admin") {
     redirect("/");
   }
 

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,4 +1,4 @@
-import { createClient } from "@/lib/supabase/server";
+import { getUser } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import LoginButton from "@/components/shared/login-button";
 
@@ -10,10 +10,7 @@ export default async function LoginPage({
   const { error } = await searchParams;
 
   // すでにログイン済みなら / にリダイレクト
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const user = await getUser();
   if (user) redirect("/");
 
   return (

--- a/src/app/(student)/lessons/[lessonId]/page.tsx
+++ b/src/app/(student)/lessons/[lessonId]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { getLessonWithQuestions } from "@/lib/db/contents";
 import { getQuizWithQuestions, hasCompletedQuiz } from "@/lib/db/quizzes";
-import { createClient } from "@/lib/supabase/server";
+import { getUserProfile } from "@/lib/supabase/server";
 import LessonContent from "@/components/lesson/lesson-content";
 
 type Props = {
@@ -12,21 +12,18 @@ type Props = {
 export default async function LessonPage({ params }: Props) {
   const { lessonId } = await params;
 
-  const supabase = await createClient();
-  const [lesson, quiz, { data: { user } }] = await Promise.all([
+  const [lesson, quiz, profile] = await Promise.all([
     getLessonWithQuestions(lessonId),
     getQuizWithQuestions(lessonId),
-    supabase.auth.getUser(),
+    getUserProfile(),
   ]);
 
   if (!lesson) return notFound();
-  if (!user) return notFound();
+  if (!profile) return notFound();
 
-  const [initialIsCompleted, profileResult] = await Promise.all([
-    quiz ? hasCompletedQuiz(quiz.id, user.id) : Promise.resolve(false),
-    supabase.from("profiles").select("role").eq("id", user.id).single(),
-  ]);
-  const currentUserRole = profileResult.data?.role ?? "student";
+  const initialIsCompleted = quiz
+    ? await hasCompletedQuiz(quiz.id, profile.userId)
+    : false;
 
   const { unit, questions } = lesson;
   const subject = unit.subject;
@@ -53,8 +50,8 @@ export default async function LessonPage({ params }: Props) {
         youtubeUrl={lesson.youtube_url}
         questions={questions}
         quiz={quiz}
-        currentUserId={user.id}
-        currentUserRole={currentUserRole}
+        currentUserId={profile.userId}
+        currentUserRole={profile.role}
         initialIsCompleted={initialIsCompleted}
       />
     </div>

--- a/src/app/(student)/page.tsx
+++ b/src/app/(student)/page.tsx
@@ -1,28 +1,17 @@
 import Image from "next/image";
 import { cookies } from "next/headers";
 import { getContents } from "@/lib/db/contents";
-import { createClient } from "@/lib/supabase/server";
+import { getUserProfile } from "@/lib/supabase/server";
 import SubjectList from "@/components/lesson/subject-list";
 
 export default async function HomePage() {
-  const [subjects, supabase, cookieStore] = await Promise.all([
+  const [subjects, profile, cookieStore] = await Promise.all([
     getContents(),
-    createClient(),
+    getUserProfile(),
     cookies(),
   ]);
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  let displayName = "";
-  if (user) {
-    const { data: profile } = await supabase
-      .from("profiles")
-      .select("display_name")
-      .eq("id", user.id)
-      .single();
-    displayName = profile?.display_name ?? "";
-  }
+  const displayName = profile?.displayName ?? "";
 
   // cookie から折りたたまれている科目IDを取得
   let initialCollapsedIds: string[] = [];

--- a/src/app/(student)/profile/page.tsx
+++ b/src/app/(student)/profile/page.tsx
@@ -1,14 +1,13 @@
 import { redirect } from "next/navigation";
-import { createClient } from "@/lib/supabase/server";
+import { createClient, getUser } from "@/lib/supabase/server";
 import ProfileEditForm from "@/components/profile/profile-edit-form";
 
 export default async function ProfilePage() {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const user = await getUser();
 
   if (!user) redirect("/login");
+
+  const supabase = await createClient();
 
   const { data: profile } = await supabase
     .from("profiles")

--- a/src/app/(teacher)/layout.tsx
+++ b/src/app/(teacher)/layout.tsx
@@ -1,25 +1,18 @@
 import { redirect } from "next/navigation";
-import { createClient, getUser } from "@/lib/supabase/server";
+import { getUserProfile } from "@/lib/supabase/server";
 
 export default async function TeacherLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const user = await getUser();
+  const profile = await getUserProfile();
 
-  if (!user) {
+  if (!profile) {
     redirect("/login");
   }
 
-  const supabase = await createClient();
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (profile?.role !== "teacher" && profile?.role !== "admin") {
+  if (profile.role !== "teacher" && profile.role !== "admin") {
     redirect("/");
   }
 

--- a/src/app/api/contents/lessons/[lessonId]/route.ts
+++ b/src/app/api/contents/lessons/[lessonId]/route.ts
@@ -1,33 +1,13 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { deleteLesson } from "@/lib/db/contents";
-import { createClient } from "@/lib/supabase/server";
-
-async function requireTeacher() {
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
-  if (!user) return null;
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (!profile || !["teacher", "admin"].includes(profile.role)) return null;
-  return user;
-}
+import { requireTeacher } from "@/lib/api/auth";
 
 export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ lessonId: string }> }
 ) {
-  const user = await requireTeacher();
-  if (!user) {
-    return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
-  }
+  const { errorResponse } = await requireTeacher();
+  if (errorResponse) return errorResponse;
 
   const { lessonId } = await params;
   const ok = await deleteLesson(lessonId);

--- a/src/app/api/contents/lessons/route.ts
+++ b/src/app/api/contents/lessons/route.ts
@@ -1,27 +1,10 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createLesson } from "@/lib/db/contents";
-import { createClient } from "@/lib/supabase/server";
+import { requireTeacher } from "@/lib/api/auth";
 
 export async function POST(request: NextRequest) {
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
-
-  if (!user) {
-    return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
-  }
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (!profile || !["teacher", "admin"].includes(profile.role)) {
-    return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
-  }
+  const { errorResponse } = await requireTeacher();
+  if (errorResponse) return errorResponse;
 
   const body = (await request.json()) as {
     unitId: string;

--- a/src/app/api/contents/subjects/[subjectId]/route.ts
+++ b/src/app/api/contents/subjects/[subjectId]/route.ts
@@ -1,33 +1,13 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { updateSubject, deleteSubject } from "@/lib/db/contents";
-import { createClient } from "@/lib/supabase/server";
-
-async function requireTeacher() {
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
-  if (!user) return null;
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (!profile || !["teacher", "admin"].includes(profile.role)) return null;
-  return user;
-}
+import { requireTeacher } from "@/lib/api/auth";
 
 export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ subjectId: string }> }
 ) {
-  const user = await requireTeacher();
-  if (!user) {
-    return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
-  }
+  const { errorResponse } = await requireTeacher();
+  if (errorResponse) return errorResponse;
 
   const { subjectId } = await params;
   const body = (await request.json()) as { name: string };
@@ -53,10 +33,8 @@ export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ subjectId: string }> }
 ) {
-  const user = await requireTeacher();
-  if (!user) {
-    return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
-  }
+  const { errorResponse } = await requireTeacher();
+  if (errorResponse) return errorResponse;
 
   const { subjectId } = await params;
   const ok = await deleteSubject(subjectId);

--- a/src/app/api/contents/subjects/route.ts
+++ b/src/app/api/contents/subjects/route.ts
@@ -1,30 +1,10 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createSubject } from "@/lib/db/contents";
-import { createClient } from "@/lib/supabase/server";
-
-async function requireTeacher() {
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
-  if (!user) return null;
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (!profile || !["teacher", "admin"].includes(profile.role)) return null;
-  return user;
-}
+import { requireTeacher } from "@/lib/api/auth";
 
 export async function POST(request: NextRequest) {
-  const user = await requireTeacher();
-  if (!user) {
-    return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
-  }
+  const { errorResponse } = await requireTeacher();
+  if (errorResponse) return errorResponse;
 
   const body = (await request.json()) as { name: string };
   if (!body.name?.trim()) {

--- a/src/app/api/contents/units/[unitId]/route.ts
+++ b/src/app/api/contents/units/[unitId]/route.ts
@@ -1,33 +1,13 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { updateUnit, deleteUnit } from "@/lib/db/contents";
-import { createClient } from "@/lib/supabase/server";
-
-async function requireTeacher() {
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
-  if (!user) return null;
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (!profile || !["teacher", "admin"].includes(profile.role)) return null;
-  return user;
-}
+import { requireTeacher } from "@/lib/api/auth";
 
 export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ unitId: string }> }
 ) {
-  const user = await requireTeacher();
-  if (!user) {
-    return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
-  }
+  const { errorResponse } = await requireTeacher();
+  if (errorResponse) return errorResponse;
 
   const { unitId } = await params;
   const body = (await request.json()) as { name: string };
@@ -53,10 +33,8 @@ export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ unitId: string }> }
 ) {
-  const user = await requireTeacher();
-  if (!user) {
-    return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
-  }
+  const { errorResponse } = await requireTeacher();
+  if (errorResponse) return errorResponse;
 
   const { unitId } = await params;
   const ok = await deleteUnit(unitId);

--- a/src/app/api/contents/units/route.ts
+++ b/src/app/api/contents/units/route.ts
@@ -1,30 +1,10 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createUnit } from "@/lib/db/contents";
-import { createClient } from "@/lib/supabase/server";
-
-async function requireTeacher() {
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
-  if (!user) return null;
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (!profile || !["teacher", "admin"].includes(profile.role)) return null;
-  return user;
-}
+import { requireTeacher } from "@/lib/api/auth";
 
 export async function POST(request: NextRequest) {
-  const user = await requireTeacher();
-  if (!user) {
-    return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
-  }
+  const { errorResponse } = await requireTeacher();
+  if (errorResponse) return errorResponse;
 
   const body = (await request.json()) as { subjectId: string; name: string };
   if (!body.subjectId || !body.name?.trim()) {

--- a/src/app/api/images/[fileId]/route.ts
+++ b/src/app/api/images/[fileId]/route.ts
@@ -1,27 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { requireTeacher } from "@/lib/api/auth";
 
 type Params = { params: Promise<{ fileId: string }> };
 
 export async function DELETE(req: NextRequest, { params }: Params) {
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
-  if (!user) {
-    return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
-  }
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (profile?.role !== "teacher" && profile?.role !== "admin") {
-    return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
-  }
+  const { errorResponse } = await requireTeacher();
+  if (errorResponse) return errorResponse;
 
   const { fileId } = await params;
 

--- a/src/app/api/images/upload/route.ts
+++ b/src/app/api/images/upload/route.ts
@@ -1,17 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { requireUser } from "@/lib/api/auth";
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 
 export async function POST(req: NextRequest) {
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
-  if (!user) {
-    return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
-  }
+  const { errorResponse } = await requireUser();
+  if (errorResponse) return errorResponse;
 
   const formData = await req.formData();
   const file = formData.get("file");

--- a/src/app/api/posts/[postId]/route.ts
+++ b/src/app/api/posts/[postId]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { requireUser } from "@/lib/api/auth";
 import { deletePost } from "@/lib/db/posts";
 
 export async function DELETE(
@@ -7,10 +7,8 @@ export async function DELETE(
   { params }: { params: Promise<{ postId: string }> }
 ) {
   const { postId } = await params;
-  const supabase = await createClient();
-  const { data: { session } } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
-  if (!user) return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
+  const { errorResponse } = await requireUser();
+  if (errorResponse) return errorResponse;
 
   const success = await deletePost(postId);
   if (!success) {

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { getUserProfile } from "@/lib/supabase/server";
 import {
   getPostsByLessonId,
   getPostsWithAuthorsByLessonId,
@@ -14,21 +14,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ data: null, error: "lessonId is required" }, { status: 400 });
   }
 
-  const supabase = await createClient();
-  const { data: { session } } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
+  const profile = await getUserProfile();
 
-  if (user) {
-    const { data: profile } = await supabase
-      .from("profiles")
-      .select("role")
-      .eq("id", user.id)
-      .single();
-
-    if (profile?.role === "teacher" || profile?.role === "admin") {
-      const data = await getPostsWithAuthorsByLessonId(lessonId);
-      return NextResponse.json({ data, error: null });
-    }
+  if (profile?.role === "teacher" || profile?.role === "admin") {
+    const data = await getPostsWithAuthorsByLessonId(lessonId);
+    return NextResponse.json({ data, error: null });
   }
 
   const data = await getPostsByLessonId(lessonId);

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { createClient, getUserProfile } from "@/lib/supabase/server";
 
 type UpdateProfileBody = {
   targetUserId?: string; // teacher/admin が他ユーザーを更新する場合に指定
@@ -9,31 +9,23 @@ type UpdateProfileBody = {
 };
 
 export async function PUT(req: Request) {
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
+  const profile = await getUserProfile();
 
-  if (!user) {
+  if (!profile) {
     return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
   }
 
-  const { data: myProfile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
   const body = (await req.json()) as UpdateProfileBody;
-  const targetUserId = body.targetUserId ?? user.id;
+  const targetUserId = body.targetUserId ?? profile.userId;
 
   // 他ユーザーを更新しようとしている場合は teacher/admin のみ許可
-  if (targetUserId !== user.id) {
-    if (myProfile?.role !== "teacher" && myProfile?.role !== "admin") {
+  if (targetUserId !== profile.userId) {
+    if (profile.role !== "teacher" && profile.role !== "admin") {
       return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
     }
   }
+
+  const supabase = await createClient();
 
   const patch: Record<string, unknown> = {};
   if (body.displayName !== undefined) patch.display_name = body.displayName;

--- a/src/app/api/quiz-questions/[questionId]/route.ts
+++ b/src/app/api/quiz-questions/[questionId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { requireTeacher } from "@/lib/api/auth";
 import { deleteQuizQuestion } from "@/lib/db/quizzes";
 
 type Params = { params: Promise<{ questionId: string }> };
@@ -7,22 +7,8 @@ type Params = { params: Promise<{ questionId: string }> };
 export async function DELETE(_req: NextRequest, { params }: Params) {
   const { questionId } = await params;
 
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
-  if (!user) return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (!profile || !["teacher", "admin"].includes(profile.role)) {
-    return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
-  }
+  const { errorResponse } = await requireTeacher();
+  if (errorResponse) return errorResponse;
 
   const ok = await deleteQuizQuestion(questionId);
   if (!ok) {

--- a/src/app/api/quizzes/[quizId]/attempts/route.ts
+++ b/src/app/api/quizzes/[quizId]/attempts/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { requireUser } from "@/lib/api/auth";
 import { createQuizAttempt, getRecentQuizAttemptsWithAnswers } from "@/lib/db/quizzes";
 import type { QuizQuestion, QuizAttemptAnswerInput } from "@/lib/db/quizzes";
 
@@ -12,10 +13,8 @@ type Params = { params: Promise<{ quizId: string }> };
 
 export async function GET(_req: NextRequest, { params }: Params) {
   const { quizId } = await params;
-  const supabase = await createClient();
-  const { data: { session } } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
-  if (!user) return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
+  const { user, errorResponse } = await requireUser();
+  if (errorResponse) return errorResponse;
 
   const attempts = await getRecentQuizAttemptsWithAnswers(quizId, user.id);
   return NextResponse.json({ data: attempts, error: null });
@@ -23,11 +22,10 @@ export async function GET(_req: NextRequest, { params }: Params) {
 
 export async function POST(req: NextRequest, { params }: Params) {
   const { quizId } = await params;
-  const supabase = await createClient();
-  const { data: { session } } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
-  if (!user) return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
+  const { user, errorResponse } = await requireUser();
+  if (errorResponse) return errorResponse;
 
+  const supabase = await createClient();
   const body = (await req.json()) as { answers: AnswerPayload[] };
   if (!Array.isArray(body.answers)) {
     return NextResponse.json({ data: null, error: "Invalid payload" }, { status: 400 });

--- a/src/app/api/quizzes/[quizId]/questions/route.ts
+++ b/src/app/api/quizzes/[quizId]/questions/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { requireTeacher } from "@/lib/api/auth";
 import { addQuizQuestion } from "@/lib/db/quizzes";
 import type { QuizQuestionType } from "@/lib/db/quizzes";
 
@@ -19,22 +19,8 @@ type QuestionPayload = {
 export async function POST(req: NextRequest, { params }: Params) {
   const { quizId } = await params;
 
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
-  if (!user) return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (!profile || !["teacher", "admin"].includes(profile.role)) {
-    return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
-  }
+  const { errorResponse } = await requireTeacher();
+  if (errorResponse) return errorResponse;
 
   const body = (await req.json()) as QuestionPayload;
 

--- a/src/app/api/quizzes/[quizId]/route.ts
+++ b/src/app/api/quizzes/[quizId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { requireTeacher } from "@/lib/api/auth";
 import { deleteQuiz } from "@/lib/db/quizzes";
 
 type Params = { params: Promise<{ quizId: string }> };
@@ -7,22 +7,8 @@ type Params = { params: Promise<{ quizId: string }> };
 export async function DELETE(_req: NextRequest, { params }: Params) {
   const { quizId } = await params;
 
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
-  if (!user) return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (!profile || !["teacher", "admin"].includes(profile.role)) {
-    return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
-  }
+  const { errorResponse } = await requireTeacher();
+  if (errorResponse) return errorResponse;
 
   const ok = await deleteQuiz(quizId);
   if (!ok) {

--- a/src/app/api/quizzes/route.ts
+++ b/src/app/api/quizzes/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { requireTeacher } from "@/lib/api/auth";
 import { createQuiz } from "@/lib/db/quizzes";
 import type { CreateQuizQuestionInput, QuizQuestionType } from "@/lib/db/quizzes";
 
@@ -21,22 +21,8 @@ type CreateQuizPayload = {
 };
 
 export async function POST(req: NextRequest) {
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
-  if (!user) return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (!profile || !["teacher", "admin"].includes(profile.role)) {
-    return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
-  }
+  const { errorResponse } = await requireTeacher();
+  if (errorResponse) return errorResponse;
 
   const body = (await req.json()) as CreateQuizPayload;
   const { lessonId, title, questions } = body;

--- a/src/app/api/teacher/lessons/[lessonId]/memo-students/[userId]/route.ts
+++ b/src/app/api/teacher/lessons/[lessonId]/memo-students/[userId]/route.ts
@@ -1,29 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { requireTeacher } from "@/lib/api/auth";
 import { getMemosByStudent } from "@/lib/db/memos";
 
 type Params = { params: Promise<{ lessonId: string; userId: string }> };
 
 export async function GET(_req: NextRequest, { params }: Params) {
   const { lessonId, userId } = await params;
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
-  if (!user) {
-    return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
-  }
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (profile?.role !== "teacher" && profile?.role !== "admin") {
-    return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
-  }
+  const { errorResponse } = await requireTeacher();
+  if (errorResponse) return errorResponse;
 
   const memos = await getMemosByStudent(lessonId, userId);
   return NextResponse.json({ data: memos, error: null });

--- a/src/app/api/teacher/lessons/[lessonId]/memo-students/route.ts
+++ b/src/app/api/teacher/lessons/[lessonId]/memo-students/route.ts
@@ -1,29 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { requireTeacher } from "@/lib/api/auth";
 import { getStudentsWithMemoCounts } from "@/lib/db/memos";
 
 type Params = { params: Promise<{ lessonId: string }> };
 
 export async function GET(req: NextRequest, { params }: Params) {
   const { lessonId } = await params;
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
-  if (!user) {
-    return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
-  }
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (profile?.role !== "teacher" && profile?.role !== "admin") {
-    return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
-  }
+  const { errorResponse } = await requireTeacher();
+  if (errorResponse) return errorResponse;
 
   const { searchParams } = req.nextUrl;
   const gradeRaw = searchParams.get("grade");

--- a/src/app/api/teacher/quiz-analytics/route.ts
+++ b/src/app/api/teacher/quiz-analytics/route.ts
@@ -1,26 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { requireTeacher } from "@/lib/api/auth";
 import { getQuizAnalytics } from "@/lib/db/quizzes";
 
 export async function GET(req: NextRequest) {
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
-  if (!user) {
-    return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
-  }
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (profile?.role !== "teacher" && profile?.role !== "admin") {
-    return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
-  }
+  const { errorResponse } = await requireTeacher();
+  if (errorResponse) return errorResponse;
 
   const { searchParams } = req.nextUrl;
   const subjectId = searchParams.get("subjectId");

--- a/src/app/api/teacher/units/[unitId]/memo-export/route.ts
+++ b/src/app/api/teacher/units/[unitId]/memo-export/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { requireTeacher } from "@/lib/api/auth";
 import {
   getUnitMemoSamplesForExport,
   type UnitMemoExportData,
@@ -36,25 +36,8 @@ export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ unitId: string }> }
 ) {
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
-
-  if (!user) {
-    return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
-  }
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (profile?.role !== "teacher" && profile?.role !== "admin") {
-    return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
-  }
+  const { errorResponse } = await requireTeacher();
+  if (errorResponse) return errorResponse;
 
   const { unitId } = await params;
   const gradeRaw = req.nextUrl.searchParams.get("grade");

--- a/src/app/api/teacher/units/[unitId]/quiz-export/route.ts
+++ b/src/app/api/teacher/units/[unitId]/quiz-export/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { requireTeacher } from "@/lib/api/auth";
 import {
   getUnitQuizResultsForExport,
   type UnitExportData,
@@ -141,25 +141,8 @@ export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ unitId: string }> }
 ) {
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
-
-  if (!user) {
-    return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
-  }
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (profile?.role !== "teacher" && profile?.role !== "admin") {
-    return NextResponse.json({ data: null, error: "Forbidden" }, { status: 403 });
-  }
+  const { errorResponse } = await requireTeacher();
+  if (errorResponse) return errorResponse;
 
   const { unitId } = await params;
   const gradeRaw = req.nextUrl.searchParams.get("grade");

--- a/src/components/shared/nav-bar.tsx
+++ b/src/components/shared/nav-bar.tsx
@@ -1,24 +1,9 @@
 import Link from "next/link";
-import { createClient } from "@/lib/supabase/server";
+import { getUserProfile } from "@/lib/supabase/server";
 import UserMenu from "@/components/shared/user-menu";
 
 export default async function NavBar() {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  let displayName = "";
-  let role: "admin" | "teacher" | "student" = "student";
-  if (user) {
-    const { data: profile } = await supabase
-      .from("profiles")
-      .select("display_name, role")
-      .eq("id", user.id)
-      .single();
-    displayName = profile?.display_name ?? user.email ?? "";
-    role = profile?.role ?? "student";
-  }
+  const profile = await getUserProfile();
 
   return (
     <header className="border-b bg-card sticky top-0 z-10">
@@ -41,7 +26,9 @@ export default async function NavBar() {
           </span>
         </Link>
         <nav className="flex items-center text-sm">
-          {user && <UserMenu displayName={displayName} role={role} />}
+          {profile && (
+            <UserMenu displayName={profile.displayName} role={profile.role} />
+          )}
         </nav>
       </div>
     </header>

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { getUser, getUserProfile } from "@/lib/supabase/server";
+
+export type AuthedUser = {
+  id: string;
+};
+
+export type AuthResult =
+  | { user: AuthedUser; errorResponse: null }
+  | { user: null; errorResponse: NextResponse };
+
+/**
+ * ログイン済みユーザーを要求する（API Route 用）。
+ * 未ログインなら 401 レスポンスを返す。
+ */
+export async function requireUser(): Promise<AuthResult> {
+  const user = await getUser();
+  if (!user) {
+    return {
+      user: null,
+      errorResponse: NextResponse.json(
+        { data: null, error: "Unauthorized" },
+        { status: 401 }
+      ),
+    };
+  }
+  return { user: { id: user.id }, errorResponse: null };
+}
+
+/**
+ * teacher / admin ロールを要求する（API Route 用）。
+ * 未ログインなら 401、権限不足なら 403 レスポンスを返す。
+ */
+export async function requireTeacher(): Promise<AuthResult> {
+  const profile = await getUserProfile();
+  if (!profile) {
+    return {
+      user: null,
+      errorResponse: NextResponse.json(
+        { data: null, error: "Unauthorized" },
+        { status: 401 }
+      ),
+    };
+  }
+  if (profile.role !== "teacher" && profile.role !== "admin") {
+    return {
+      user: null,
+      errorResponse: NextResponse.json(
+        { data: null, error: "Forbidden" },
+        { status: 403 }
+      ),
+    };
+  }
+  return { user: { id: profile.userId }, errorResponse: null };
+}

--- a/src/lib/db/contents.ts
+++ b/src/lib/db/contents.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@/lib/supabase/server";
+import { createClient, getUser } from "@/lib/supabase/server";
 import type { Database } from "@/lib/supabase/types";
 
 export type Subject = Database["public"]["Tables"]["subjects"]["Row"];
@@ -57,9 +57,7 @@ export async function getContents(): Promise<SubjectWithUnits[]> {
  */
 export async function createSubject(name: string): Promise<Subject | null> {
   const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const user = await getUser();
   if (!user) return null;
 
   const { count } = await supabase

--- a/src/lib/db/contents.ts
+++ b/src/lib/db/contents.ts
@@ -15,39 +15,25 @@ export type LessonWithQuestions = Lesson & {
 };
 
 /**
- * 科目・単元・レッスン一覧を取得する
+ * 科目・単元・レッスン一覧を取得する（ネスト select で1クエリ）
  */
 export async function getContents(): Promise<SubjectWithUnits[]> {
   const supabase = await createClient();
 
-  const { data: subjects, error: subjectsError } = await supabase
+  const { data, error } = await supabase
     .from("subjects")
-    .select("*")
+    .select("*, units(*, lessons(*))")
     .order("order");
 
-  if (subjectsError || !subjects) return [];
+  if (error || !data) return [];
 
-  const { data: units, error: unitsError } = await supabase
-    .from("units")
-    .select("*")
-    .order("order");
-
-  if (unitsError || !units) return [];
-
-  const { data: lessons, error: lessonsError } = await supabase
-    .from("lessons")
-    .select("*")
-    .order("order");
-
-  if (lessonsError || !lessons) return [];
-
-  return subjects.map((subject) => ({
+  return data.map((subject) => ({
     ...subject,
-    units: units
-      .filter((unit) => unit.subject_id === subject.id)
+    units: [...subject.units]
+      .sort((a, b) => a.order - b.order)
       .map((unit) => ({
         ...unit,
-        lessons: lessons.filter((lesson) => lesson.unit_id === unit.id),
+        lessons: [...unit.lessons].sort((a, b) => a.order - b.order),
       })),
   }));
 }
@@ -190,7 +176,7 @@ export async function createLesson(params: {
 }
 
 /**
- * レッスン詳細と発問を取得する
+ * レッスン詳細と発問を取得する（ネスト select で1クエリ）
  */
 export async function getLessonWithQuestions(
   lessonId: string
@@ -199,22 +185,14 @@ export async function getLessonWithQuestions(
 
   const { data: lesson, error: lessonError } = await supabase
     .from("lessons")
-    .select("*, unit:units(*, subject:subjects(*))")
+    .select("*, unit:units(*, subject:subjects(*)), questions(*)")
     .eq("id", lessonId)
     .single();
 
   if (lessonError || !lesson) return null;
 
-  const { data: questions, error: questionsError } = await supabase
-    .from("questions")
-    .select("*")
-    .eq("lesson_id", lessonId)
-    .order("order");
-
-  if (questionsError) return null;
-
   return {
     ...lesson,
-    questions: questions ?? [],
+    questions: [...lesson.questions].sort((a, b) => a.order - b.order),
   };
 }

--- a/src/lib/db/memos.ts
+++ b/src/lib/db/memos.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@/lib/supabase/server";
+import { createClient, getUser } from "@/lib/supabase/server";
 import type { Database } from "@/lib/supabase/types";
 import { tiptapDocToText } from "@/lib/tiptap-utils";
 
@@ -26,9 +26,7 @@ export type TiptapContent = {
  */
 export async function getMemosByLessonId(lessonId: string): Promise<Memo[]> {
   const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const user = await getUser();
   if (!user) return [];
 
   const { data, error } = await supabase
@@ -51,9 +49,7 @@ export async function createMemo(params: {
   timestampSeconds: number | null;
 }): Promise<Memo | null> {
   const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const user = await getUser();
   if (!user) return null;
 
   const { data, error } = await supabase
@@ -76,9 +72,7 @@ export async function createMemo(params: {
  */
 export async function getAllMemos(): Promise<Memo[]> {
   const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const user = await getUser();
   if (!user) return [];
 
   const { data, error } = await supabase

--- a/src/lib/db/memos.ts
+++ b/src/lib/db/memos.ts
@@ -201,19 +201,16 @@ export async function getUnitMemoSamplesForExport(
 ): Promise<UnitMemoExportData | null> {
   const supabase = await createClient();
 
+  // 単元とレッスンをネスト select で1クエリで取得
   const { data: unit } = await supabase
     .from("units")
-    .select("name")
+    .select("name, lessons(id, title, order)")
     .eq("id", unitId)
     .single();
   if (!unit) return null;
 
-  const { data: lessons } = await supabase
-    .from("lessons")
-    .select("id, title, order")
-    .eq("unit_id", unitId)
-    .order("order");
-  if (!lessons || lessons.length === 0) return null;
+  const lessons = [...unit.lessons].sort((a, b) => a.order - b.order);
+  if (lessons.length === 0) return null;
 
   const lessonIds = lessons.map((l) => l.id);
 

--- a/src/lib/db/posts.ts
+++ b/src/lib/db/posts.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@/lib/supabase/server";
+import { createClient, getUser } from "@/lib/supabase/server";
 import type { Database } from "@/lib/supabase/types";
 import type { TiptapContent } from "@/lib/db/memos";
 
@@ -78,9 +78,7 @@ export async function createPost(params: {
   timestampSeconds: number | null;
 }): Promise<Post | null> {
   const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const user = await getUser();
   if (!user) return null;
 
   const { data, error } = await supabase

--- a/src/lib/db/quizzes.ts
+++ b/src/lib/db/quizzes.ts
@@ -36,7 +36,7 @@ export type QuizAttemptAnswerInput = {
 };
 
 /**
- * レッスンに紐づくクイズと問題一覧を取得する
+ * レッスンに紐づくクイズと問題一覧を取得する（ネスト select で1クエリ）
  */
 export async function getQuizWithQuestions(
   lessonId: string
@@ -45,21 +45,16 @@ export async function getQuizWithQuestions(
 
   const { data: quiz, error: quizError } = await supabase
     .from("quizzes")
-    .select("*")
+    .select("*, questions:quiz_questions(*)")
     .eq("lesson_id", lessonId)
     .maybeSingle();
 
   if (quizError || !quiz) return null;
 
-  const { data: questions, error: questionsError } = await supabase
-    .from("quiz_questions")
-    .select("*")
-    .eq("quiz_id", quiz.id)
-    .order("order");
-
-  if (questionsError) return null;
-
-  return { ...quiz, questions: questions ?? [] };
+  return {
+    ...quiz,
+    questions: [...quiz.questions].sort((a, b) => a.order - b.order),
+  };
 }
 
 /**
@@ -365,18 +360,15 @@ export async function getQuizAnalytics(
 ): Promise<QuizAnalyticsResult | null> {
   const supabase = await createClient();
 
+  // 科目・単元・レッスンをネスト select で1クエリで取得
   const { data: subject } = await supabase
     .from("subjects")
-    .select("name")
+    .select("name, units(id, name, order, lessons(id, title, order, unit_id))")
     .eq("id", subjectId)
     .single();
   if (!subject) return null;
 
-  const { data: units } = await supabase
-    .from("units")
-    .select("id, name")
-    .eq("subject_id", subjectId)
-    .order("order");
+  const units = [...subject.units].sort((a, b) => a.order - b.order);
 
   const emptyResult: QuizAnalyticsResult = {
     subjectId,
@@ -384,31 +376,26 @@ export async function getQuizAnalytics(
     lessons: [],
   };
 
-  if (!units || units.length === 0) return emptyResult;
+  if (units.length === 0) return emptyResult;
 
-  const unitIds = units.map((u) => u.id);
-  const { data: lessons } = await supabase
-    .from("lessons")
-    .select("id, title, unit_id")
-    .in("unit_id", unitIds)
-    .order("order");
-  if (!lessons || lessons.length === 0) return emptyResult;
+  const lessons = units
+    .flatMap((u) => u.lessons)
+    .sort((a, b) => a.order - b.order);
+  if (lessons.length === 0) return emptyResult;
 
   const lessonIds = lessons.map((l) => l.id);
 
+  // クイズと問題をネスト select で1クエリで取得
   const { data: quizzes } = await supabase
     .from("quizzes")
-    .select("id, lesson_id")
+    .select("id, lesson_id, quiz_questions(id, quiz_id, type, content, order)")
     .in("lesson_id", lessonIds);
   if (!quizzes || quizzes.length === 0) return emptyResult;
 
   const quizIds = quizzes.map((q) => q.id);
-  const { data: questions } = await supabase
-    .from("quiz_questions")
-    .select("id, quiz_id, type, content, order")
-    .in("quiz_id", quizIds)
-    .order("order");
-  if (!questions) return null;
+  const questions = quizzes
+    .flatMap((q) => q.quiz_questions)
+    .sort((a, b) => a.order - b.order);
 
   // フィルタされた生徒IDを取得
   let profilesQuery = supabase
@@ -569,37 +556,34 @@ export async function getUnitQuizResultsForExport(
 ): Promise<UnitExportData | null> {
   const supabase = await createClient();
 
+  // 単元とレッスンをネスト select で1クエリで取得
   const { data: unit } = await supabase
     .from("units")
-    .select("name")
+    .select("name, lessons(id, title, order)")
     .eq("id", unitId)
     .single();
   if (!unit) return null;
 
-  const { data: lessons } = await supabase
-    .from("lessons")
-    .select("id, title, order")
-    .eq("unit_id", unitId)
-    .order("order");
-  if (!lessons || lessons.length === 0) return null;
+  const lessons = [...unit.lessons].sort((a, b) => a.order - b.order);
+  if (lessons.length === 0) return null;
 
   const lessonIds = lessons.map((l) => l.id);
 
+  // クイズと問題をネスト select で1クエリで取得
   const { data: quizzes } = await supabase
     .from("quizzes")
-    .select("id, lesson_id")
+    .select(
+      "id, lesson_id, quiz_questions(id, quiz_id, type, content, correct_answer, options, order)"
+    )
     .in("lesson_id", lessonIds);
   if (!quizzes || quizzes.length === 0) return null;
 
   const quizIds = quizzes.map((q) => q.id);
   const quizByLesson = new Map(quizzes.map((q) => [q.lesson_id, q.id]));
 
-  const { data: questions } = await supabase
-    .from("quiz_questions")
-    .select("id, quiz_id, type, content, correct_answer, options, order")
-    .in("quiz_id", quizIds)
-    .order("order");
-  if (!questions) return null;
+  const questions = quizzes
+    .flatMap((q) => q.quiz_questions)
+    .sort((a, b) => a.order - b.order);
 
   // 対象学年の生徒を全員取得
   const { data: profiles } = await supabase

--- a/src/lib/db/quizzes.ts
+++ b/src/lib/db/quizzes.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@/lib/supabase/server";
+import { createClient, getUser } from "@/lib/supabase/server";
 import type { Database } from "@/lib/supabase/types";
 import { tiptapDocToText } from "@/lib/tiptap-utils";
 
@@ -241,7 +241,7 @@ export type QuizAttemptResult = {
  */
 export async function getQuizResultsByUser(): Promise<QuizAttemptResult[]> {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const user = await getUser();
   if (!user) return [];
 
   const { data, error } = await supabase

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -39,10 +39,11 @@ export async function updateSession(request: NextRequest) {
     }
   );
 
-  // セッションを更新（必ずgetUser()を呼ぶ）
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  // セッションを更新し JWT を検証する。
+  // JWT Signing Keys（非対称鍵）移行後は Auth サーバーへの通信なしでローカル検証される。
+  // 移行前は自動的に従来どおりサーバー問い合わせで検証される。
+  const { data } = await supabase.auth.getClaims();
+  const user = data?.claims ?? null;
 
   // 未認証ユーザーを /login にリダイレクト（認証不要パスを除く）
   const pathname = request.nextUrl.pathname;

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -42,16 +42,20 @@ export async function createClient() {
 }
 
 /**
- * ログインユーザーの ID・メールアドレスを JWT クレームから取得する。
- * JWT Signing Keys（非対称鍵）移行後は Auth サーバーへの通信なしでローカル検証される。
+ * ログインユーザーの ID・メールアドレスを取得する（Auth サーバーへの通信なし）。
+ *
+ * JWT の署名検証はミドルウェア（proxy.ts → updateSession）が全リクエストで
+ * getClaims() により実施済みのため、ここでは Cookie のセッションを信頼して読み取る。
  * React cache により同一リクエスト内では1回だけ実行される。
  */
 export const getUser = cache(async () => {
   const supabase = await createClient();
-  const { data } = await supabase.auth.getClaims();
-  const claims = data?.claims;
-  if (!claims) return null;
-  return { id: claims.sub, email: claims.email };
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user;
+  if (!user) return null;
+  return { id: user.id, email: user.email };
 });
 
 export type Role = Database["public"]["Enums"]["role"];

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -41,12 +41,17 @@ export async function createClient() {
   );
 }
 
+/**
+ * ログインユーザーの ID・メールアドレスを JWT クレームから取得する。
+ * JWT Signing Keys（非対称鍵）移行後は Auth サーバーへの通信なしでローカル検証される。
+ * React cache により同一リクエスト内では1回だけ実行される。
+ */
 export const getUser = cache(async () => {
   const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  return user;
+  const { data } = await supabase.auth.getClaims();
+  const claims = data?.claims;
+  if (!claims) return null;
+  return { id: claims.sub, email: claims.email };
 });
 
 export type Role = Database["public"]["Enums"]["role"];

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,6 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import { cache } from "react";
+import type { Database } from "@/lib/supabase/types";
 
 export async function createClient() {
   const cookieStore = await cookies();
@@ -46,4 +47,34 @@ export const getUser = cache(async () => {
     data: { user },
   } = await supabase.auth.getUser();
   return user;
+});
+
+export type Role = Database["public"]["Enums"]["role"];
+
+export type UserProfile = {
+  userId: string;
+  displayName: string;
+  role: Role;
+};
+
+/**
+ * ログインユーザーのプロフィール（表示名・ロール）を取得する。
+ * React cache により同一リクエスト内では認証確認・profiles クエリとも1回だけ実行される。
+ */
+export const getUserProfile = cache(async (): Promise<UserProfile | null> => {
+  const user = await getUser();
+  if (!user) return null;
+
+  const supabase = await createClient();
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("display_name, role")
+    .eq("id", user.id)
+    .single();
+
+  return {
+    userId: user.id,
+    displayName: profile?.display_name ?? user.email ?? "",
+    role: profile?.role ?? "student",
+  };
 });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,7 +12,8 @@ export const config = {
      * - _next/static（静的ファイル）
      * - _next/image（画像最適化）
      * - favicon.ico
+     * - 画像などの静的アセット（認証チェック不要のため除外し、Auth への通信を削減）
      */
-    "/((?!_next/static|_next/image|favicon.ico).*)",
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)",
   ],
 };


### PR DESCRIPTION
## 概要
Supabase 無料枠のレート制限超過によるエラーを解消するため、認証系・DB系の通信量を削減するリファクタリングを実施。

## 変更内容
- **共有認証ヘルパー `getUserProfile()` を導入** — NavBar・layout・各ページで重複していた認証確認 + profiles クエリを React cache で1リクエストあたり1回に統一（従来はページ表示ごとに Auth API 最大4回 + profiles 重複クエリ2〜3回）
- **ミドルウェアを `getClaims()` によるJWTローカル検証に変更** — 全リクエストで発生していた Auth サーバーへの通信がゼロになる（本プロジェクトは JWT Signing Keys 移行済みのため、デプロイ直後からローカル検証で動作）
- **サーバー内部の `getUser()` を Cookie セッション読み取りに変更** — 署名検証はミドルウェアに一元化し、下流での Auth 通信を排除
- **API Route の認証を `requireUser()` / `requireTeacher()` に共通化** — 18ルートにコピペされていたボイラープレート（約240行）を削除。生徒用ルートでは profiles クエリ自体が不要に
- **逐次DBクエリをネスト select に統合** — `getContents` 3→1、`getLessonWithQuestions` 2→1、`getQuizWithQuestions` 2→1、`getQuizAnalytics` 5→2、`getUnitQuizResultsForExport` 4→2、`getUnitMemoSamplesForExport` 2→1
- **ミドルウェアの matcher から画像等の静的アセットを除外** — SVG 等の取得で発生していた不要な認証チェックを削減

## 確認事項
- [x] セルフレビュー済み
- [x] JWT Signing Keys は移行済みであることを確認（Current key: ECC P-256）— ダッシュボード操作は不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)